### PR TITLE
Handle omitted mysql service

### DIFF
--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -562,7 +562,7 @@
 #   servers = ["127.0.0.1:27017"]
 
 
-<% config_file['mysql'].each do |server_url| %>
+<% (config_file['mysql'] || []).each do |server_url| %>
 # # Read metrics from one or many mysql servers
 [[inputs.mysql]]
   ## specify servers via a url matching:


### PR DESCRIPTION
This branch addresses an issue with #3 which causes ERB to fail rendering the config template when no MySQL service is defined, as in the default config.

Here's what the error looks like:


```
$ ./bin/instrumentald -c conf/instrumental.toml
instrumentald version 1.0.0 started at 2016-07-12 16:29:29 UTC
Collecting stats under the hostname: moot.attlocal.net
(erb):565:in `block in process_telegraf_config': undefined method `each' for nil:NilClass (NoMethodError)
	from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/2.1.0/erb.rb:850:in `eval'
	from /usr/local/var/rbenv/versions/2.1.5/lib/ruby/2.1.0/erb.rb:850:in `result'
	from /Users/jqr/code/instrumental/daemon/lib/instrumentald/server_controller.rb:196:in `block in process_telegraf_config'
	from /Users/jqr/code/instrumental/daemon/lib/instrumentald/server_controller.rb:195:in `open'
	from /Users/jqr/code/instrumental/daemon/lib/instrumentald/server_controller.rb:195:in `process_telegraf_config'
	from /Users/jqr/code/instrumental/daemon/lib/instrumentald/server_controller.rb:205:in `run'
	from /Users/jqr/code/instrumental/daemon/lib/instrumentald/server_controller.rb:46:in `foreground'
```