### PR TITLE
Add network tracking with telegraf

### DIFF
--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -562,7 +562,7 @@
 #   servers = ["127.0.0.1:27017"]
 
 
-<% config_file['mysql'].each do |server_url| %>
+<% (config_file['mysql'] || []).each do |server_url| %>
 # # Read metrics from one or many mysql servers
 [[inputs.mysql]]
   ## specify servers via a url matching:

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -626,7 +626,7 @@
 
 
 # # Read metrics about network interface usage
-# [[inputs.net]]
+[[inputs.net]]
 #   ## By default, telegraf gathers stats from any up interface (excluding loopback)
 #   ## Setting interfaces will tell it to gather these explicit interfaces,
 #   ## regardless of status.


### PR DESCRIPTION
**WARNING:** This brach includes the fix in #5 to ease in testing.

This branch enables network tracking in telegraf by default.

It adds the following 8 metrics per interface:
- bytes_recv
- bytes_sent
- drop_in
- drop_out
- err_in
- err_out
- packets_recv
- packets_sent