### PR TITLE
Use a better shorthand for passing a config file

### DIFF
--- a/bin/instrumentald
+++ b/bin/instrumentald
@@ -69,7 +69,7 @@ Default command: #{default_command.to_s}
     run_options[:api_key] = api_key
   end
 
-  opts.on('-f', '--config-file PATH', "Configuration path, required if using services(MySQL, redis, etc.) or if API key is not specififed. (default #{default_options[:config_file]})") do |path|
+  opts.on('-c', '--config-file PATH', "Configuration path, required if using services(MySQL, redis, etc.) or if API key is not specififed. (default #{default_options[:config_file]})") do |path|
     run_options[:config_file] = coerce_path(path)
   end
 

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -562,7 +562,7 @@
 #   servers = ["127.0.0.1:27017"]
 
 
-<% config_file['mysql'].each do |server_url| %>
+<% (config_file['mysql'] || []).each do |server_url| %>
 # # Read metrics from one or many mysql servers
 [[inputs.mysql]]
   ## specify servers via a url matching:


### PR DESCRIPTION
**WARNING:** This brach includes the fix in #5 to ease in testing.

This branch changes the shorthand option for passing a config file from -f to -c to make it more obvious.

