### PR TITLE
Updated a few references to /etc/instrumental.toml to /etc/instrumentald.toml, which we use more commonly.

### DIFF
--- a/bin/instrumentald
+++ b/bin/instrumentald
@@ -50,7 +50,7 @@ default_options = {
   :script_location => default_script_directory,
   :report_interval => 30,
   :debug           => false,
-  :config_file     => '/etc/instrumental.toml',
+  :config_file     => '/etc/instrumentald.toml',
   :user            => nil
 }
 run_options = {}

--- a/chef/instrumentald/attributes/default.rb
+++ b/chef/instrumentald/attributes/default.rb
@@ -14,11 +14,11 @@ default[:instrumental][:enable_scripts]  = false
 
 if node[:platform_family] == "windows"
   default[:instrumental][:destination_dir] = "C:\\Program Files (x86)\\Instrumental Tools"
-  default[:instrumental][:config_file]     = "C:\\Program Files (x86)\\Instrumental Tools\\etc\\instrumental.toml"
+  default[:instrumental][:config_file]     = "C:\\Program Files (x86)\\Instrumental Tools\\etc\\instrumentald.toml"
   default[:instrumental][:script_dir]      = "C:\\Program Files (x86)\\Instrumental Tools\\scripts"
 else
   default[:instrumental][:destination_dir] = "/opt/instrumentald/"
-  default[:instrumental][:config_file]     = "/etc/instrumental.toml"
+  default[:instrumental][:config_file]     = "/etc/instrumentald.toml"
   default[:instrumental][:script_dir]      = "/opt/instrumentald/.scripts"
   default[:instrumental][:pid_file]        = "/opt/instrumentald/instrumentald.pid"
   default[:instrumental][:log_file]        = "/opt/instrumentald/instrumentald.log"


### PR DESCRIPTION
This should fix an issue with running instrumentald after installing it and editing the config.