### PR TITLE
Automated Postgresql Metrics

### DIFF
--- a/conf/instrumental.toml
+++ b/conf/instrumental.toml
@@ -6,3 +6,4 @@ api_key = "YOUR_API_KEY"
 # redis = ["tcp://localhost:6379"]
 # memcached = ["localhost:11211"]
 # mysql = ["root@tcp(127.0.0.1:3306)/"]
+# postgresql = ["postgres://postgres@localhost?sslmode=disable"]

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -191,6 +191,7 @@ class ServerController < Pidly::Control
     instrumental_api_key = configured_api_key
     redis_servers = config_file['redis']
     memcached_servers = config_file['memcached']
+    postgresql_servers = config_file['postgresql'] || []
 
     File.open(telegraf_config_path, "w+") do |config|
       result = ERB.new(File.read(telegraf_template_config_path)).result(binding)

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -748,64 +748,71 @@
 #   ## databases are gathered.
 #   # databases = ["app_production", "testing"]
 
+<% postgresql_servers.each do |server_url| %>
+# Read metrics from one or many postgresql servers
+[[inputs.postgresql_extensible]]
+  ## specify address via a url matching:
+  ##   postgres://[pqgotest[:password]]@localhost[/dbname]\
+  ##       ?sslmode=[disable|verify-ca|verify-full]
+  ## or a simple string:
+  ##   host=localhost user=pqotest password=... sslmode=... dbname=app_production
+  #
+  ## All connection parameters are optional.  #
+  ## Without the dbname parameter, the driver will default to a database
+  ## with the same name as the user. This dbname is just for instantiating a
+  ## connection with the server and doesn't restrict the databases we are trying
+  ## to grab metrics for.
+  #
+  address = "<%= server_url %>"
 
-# # Read metrics from one or many postgresql servers
-# [[inputs.postgresql_extensible]]
-#   ## specify address via a url matching:
-#   ##   postgres://[pqgotest[:password]]@localhost[/dbname]\
-#   ##       ?sslmode=[disable|verify-ca|verify-full]
-#   ## or a simple string:
-#   ##   host=localhost user=pqotest password=... sslmode=... dbname=app_production
-#   #
-#   ## All connection parameters are optional.  #
-#   ## Without the dbname parameter, the driver will default to a database
-#   ## with the same name as the user. This dbname is just for instantiating a
-#   ## connection with the server and doesn't restrict the databases we are trying
-#   ## to grab metrics for.
-#   #
-#   address = "host=localhost user=postgres sslmode=disable"
-#   ## A list of databases to pull metrics about. If not specified, metrics for all
-#   ## databases are gathered.
-#   ## databases = ["app_production", "testing"]
-#   #
-#   # outputaddress = "db01"
-#   ## A custom name for the database that will be used as the "server" tag in the
-#   ## measurement output. If not specified, a default one generated from
-#   ## the connection address is used.
-#   #
-#   ## Define the toml config where the sql queries are stored
-#   ## New queries can be added, if the withdbname is set to true and there is no
-#   ## databases defined in the 'databases field', the sql query is ended by a
-#   ## 'is not null' in order to make the query succeed.
-#   ## Example :
-#   ## The sqlquery : "SELECT * FROM pg_stat_database where datname" become
-#   ## "SELECT * FROM pg_stat_database where datname IN ('postgres', 'pgbench')"
-#   ## because the databases variable was set to ['postgres', 'pgbench' ] and the
-#   ## withdbname was true. Be careful that if the withdbname is set to false you
-#   ## don't have to define the where clause (aka with the dbname) the tagvalue
-#   ## field is used to define custom tags (separated by commas)
-#   ## The optional "measurement" value can be used to override the default
-#   ## output measurement name ("postgresql").
-#   #
-#   ## Structure :
-#   ## [[inputs.postgresql_extensible.query]]
-#   ##   sqlquery string
-#   ##   version string
-#   ##   withdbname boolean
-#   ##   tagvalue string (comma separated)
-#   ##   measurement string
-#   [[inputs.postgresql_extensible.query]]
-#     sqlquery="SELECT * FROM pg_stat_database"
-#     version=901
-#     withdbname=false
-#     tagvalue=""
-#     measurement=""
-#   [[inputs.postgresql_extensible.query]]
-#     sqlquery="SELECT * FROM pg_stat_bgwriter"
-#     version=901
-#     withdbname=false
-#     tagvalue="postgresql.stats"
+  # Don't include server or host as part of the metric name, but instead read from
+  # the server config string
+  tagexclude = ["server", "host"]
 
+  ## A list of databases to pull metrics about. If not specified, metrics for all
+  ## databases are gathered.
+  ## databases = ["app_production", "testing"]
+  #
+  ## A custom name for the database that will be used as the "server" tag in the
+  ## measurement output. If not specified, a default one generated from
+  ## the connection address is used.
+  #  outputaddress = "db01"
+  ## Define the toml config where the sql queries are stored
+  ## New queries can be added, if the withdbname is set to true and there is no
+  ## databases defined in the 'databases field', the sql query is ended by a
+  ## 'is not null' in order to make the query succeed.
+  ## Example :
+  ## The sqlquery : "SELECT * FROM pg_stat_database where datname" become
+  ## "SELECT * FROM pg_stat_database where datname IN ('postgres', 'pgbench')"
+  ## because the databases variable was set to ['postgres', 'pgbench' ] and the
+  ## withdbname was true. Be careful that if the withdbname is set to false you
+  ## don't have to define the where clause (aka with the dbname) the tagvalue
+  ## field is used to define custom tags (separated by commas)
+  ## The optional "measurement" value can be used to override the default
+  ## output measurement name ("postgresql").
+  #
+  ## Structure :
+  ## [[inputs.postgresql_extensible.query]]
+  ##   sqlquery string
+  ##   version string
+  ##   withdbname boolean
+  ##   tagvalue string (comma separated)
+  ##   measurement string
+  <% server_part = server_url.split("@").last.split("?").first.strip %>
+  <% server_part = ".#{server_part}" unless server_part.empty? %>
+  [[inputs.postgresql_extensible.query]]
+    sqlquery="SELECT * FROM pg_stat_database WHERE datname"
+    version=901
+    withdbname=true
+    tagvalue=""
+    measurement="postgresql<%= server_part %>"
+  [[inputs.postgresql_extensible.query]]
+    sqlquery="SELECT * FROM pg_stat_bgwriter"
+    version=901
+    withdbname=false
+    tagvalue=""
+    measurement="postgresql<%= server_part %>"
+<% end %>
 
 # # Read metrics from one or many PowerDNS servers
 # [[inputs.powerdns]]


### PR DESCRIPTION
This is heavily based on the work @jason-o-matic did for mysql in #3 , though using postgresql's metric collections, which makes the whole thing a bit more flexible. You can read about that [here](https://www.postgresql.org/docs/9.2/static/monitoring-stats.html).

There is not currently a way to limit via `instrumentald` the databases from which we gather stats, though it's not difficult to do with the config. So currently it will gather stats from all databases that can be accessed using the connection string. In a production environment, that is (probably) only going to be one database, but in development when testing this, it could be many.

Some samples from Instrumental:

Metric list. _Note that `postgres` has more metrics because the cluster-wide metrics from `pg_stat_bgwriter` go into that bucket._
<img width="475" alt="screen shot 2016-07-13 at 12 01 43 pm" src="https://cloud.githubusercontent.com/assets/50124/16811077/acbbb58a-48f4-11e6-99ef-b1355127b13a.png">

Metrics for `postgres` db:
<img width="562" alt="screen shot 2016-07-13 at 12 01 35 pm" src="https://cloud.githubusercontent.com/assets/50124/16811081/b798ccae-48f4-11e6-8eef-bf7e3b33f4c4.png">

Metrics for a test db:
<img width="451" alt="screen shot 2016-07-13 at 12 01 50 pm" src="https://cloud.githubusercontent.com/assets/50124/16811084/be652672-48f4-11e6-90b8-945d41c5956c.png">

Running some inserts through the test database:
![inserts](https://cloud.githubusercontent.com/assets/50124/16811089/c2fe22ec-48f4-11e6-8778-9e3c6e5fe43e.png)

-----

I think it would be neat to add these stats optionally, and probably check out the book mentioned here:
http://stackoverflow.com/questions/17699260/whats-the-unit-of-buffers-checkpoint-in-pg-stat-bgwriter-table/17704517#17704517

-----

Here are my notes on the metrics that we get from postgres using the queries in this PR:

### Postgresql Measurements:

* `blk_read_time`
  * Time spent reading data file blocks by backends in this database, in milliseconds
  * instrumentald value: 0
  * suggested graph: `series_derivative(*.blk_read_time)`

* `blk_write_time`
  * Time spent writing data file blocks by backends in this database, in milliseconds
  * instrumentald value: 0
  * suggested graph: `series_derivative(*.blk_write_time)`

* `blks_read`
  * Number of disk blocks read in this database
  * instrumentald value: 0
  * suggested graph: `series_derivative(*.blks_read)`

* `blks_hit`
  * Number of times disk blocks were found already in the buffer cache, so that a read was not necessary (this only includes hits in the PostgreSQL buffer cache, not the operating system's file system cache)
  * Instrumentald Value: 0
  * suggested graph: `series_derivative(*.blks_hit)`

* `buffers_alloc`
  * Number of buffers allocated
  * instrumentald value: -3
  * suggested graph: `series_derivative(*.buffers_alloc)`

* `buffers_backend`
  * Number of buffers written directly by a backend
  * instrumentald value: -2
  * suggested graph: `series_derivative(*.buffers_backend)`

* `buffers_backend_fsync`
  * Number of times a backend had to execute its own fsync call (normally the background writer handles those even when the backend does its own write)
  * instrumentald value: -3
  * suggested graph: `series_derivative(*.buffers_backend_fsync)`

* `buffers_checkpoint`
  * Number of buffers written during checkpoints
  * instrumentald value: -1
  * suggested graph: `series_derivative(*.buffers_checkpoint)`

* `buffers_clean`
  * Number of buffers written by the background writer
  * instrumentald value: -1
  * suggested graph: `series_derivative(*.buffers_clean)`

* `checkpoint_sync_time`
  * Total amount of time that has been spent in the portion of checkpoint processing where files are synchronized to disk, in milliseconds
  * instrumentald value: -2
  * suggested graph: `series_derivative(*.checkpoint_sync_time)`

* `checkpoint_write_time`
  * Total amount of time that has been spent in the portion of checkpoint processing where files are written to disk, in milliseconds
  * instrumentald value: 0
  * suggested graph: `series_derivative(*.checkpoint_write_time)`

* `checkpoints_timed`
  * Number of scheduled checkpoints that have been performed
  * instrumentald value: -2
  * suggested graph: `series_derivative(*.checkpoints_timed)`

* `checkpoints_req`
  * Number of requested checkpoints that have been performed
  * instrumentald value: 0 (I believe this is user-requested checkpoints, so it has more value than others)
  * suggested graph: `series_derivative(*.checkpoints_req)`

* `conflicts`
  * Number of queries canceled due to conflicts with recovery in this database. (Conflicts occur only on standby servers; see pg_stat_database_conflicts for details.)
  * instrumentald value: 0
  * suggested graph: `series_derivative(*.conflicts)`

* `deadlocks`
  * Number of deadlocks detected in this database
  * instrumentald value: 0
  * suggested graph: `series_derivative(*.deadlocks)`

* `maxwritten_clean`
  * Number of times the background writer stopped a cleaning scan because it had written too many buffers
  * instrumentald value: -2
  * suggested graph: `series_derivative(*.maxwritten_clean)`

* `numbackends`
  * Number of backends currently connected to this database. This is the only column in this view that returns a value reflecting current state; all other columns return the accumulated values since the last reset.
  * instrumentald value: 2
  * suggested graph: *.numbackends

* `temp_bytes`
  * Total amount of data written to temporary files by queries in this database. All temporary files are counted, regardless of why the temporary file was created, and regardless of the log_temp_files setting.
  * instrumentald value: -1
  * suggested graph: `series_derivative(*.temp_bytes)`

* `temp_files`
  * Number of temporary files created by queries in this database. All temporary files are counted, regardless of why the temporary file was created (e.g., sorting or hashing), and regardless of the log_temp_files setting.
  * instrumentald value: -1
  * suggested graph: `series_derivative(*.temp_files)`

* `tup_deleted`
  * Number of rows deleted by queries in this database
  * Instrumentald Value: 3
  * suggested graph: `series_derivative(*.tup_deleted)`

* `tup_fetched`
  * Number of rows fetched by queries in this database
  * Instrumentald Value: 3
  * suggested graph: `series_derivative(*.tup_fetched)`

* `tup_inserted`
  * Number of rows inserted by queries in this database
  * Instrumentald Value: 3
  * suggested graph: `series_derivative(*.tup_inserted)`

* `tup_returned`
  * Number of rows returned by queries in this database
  * Instrumentald Value: 3
  * suggested graph: `series_derivative(*.tup_returned)`

* `tup_updated`
  * Number of rows updated by queries in this database
  * Instrumentald Value: 3
  * suggested graph: `series_derivative(*.tup_updated)`

* `xact_commit`
  * Number of transactions in this database that have been committed
  * instrumentald value: 2
  * suggested graph: `series_derivative(*.xact_commit)`

* `xact_rollback`
  * Number of transactions in this database that have been rolled back
  * instrumentald value: 1
  * suggested graph: `series_derivative(*.xact_rollback)`

