### PR TITLE
Updated instrumentald to run telegraf in a way that's easier to clean up.

### DIFF
--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -32,7 +32,7 @@ class ServerController < Pidly::Control
   def initialize(options={})
     @run_options = options.delete(:run_options) || {}
     @default_options = options.delete(:default_options) || {}
-    @telegraf_config_tempfile = Tempfile.new("instrumentald_telegraph")
+    @telegraf_config_tempfile = Tempfile.new("instrumentald_telegraf")
     super(options)
   end
 
@@ -204,7 +204,7 @@ class ServerController < Pidly::Control
     puts "Collecting stats under the hostname: #{hostname}"
 
     process_telegraf_config
-    run_telegraph
+    run_telegraf
 
     loop do
       sleep time_to_sleep
@@ -229,7 +229,7 @@ class ServerController < Pidly::Control
     end
   end
 
-  def run_telegraph
+  def run_telegraf
     instrumentald_pid = Process.pid
     daemonize_block do
       $0 = "[Monitor] #{$0}"
@@ -245,7 +245,7 @@ class ServerController < Pidly::Control
 
         # if we get here instrumentald has exited and we need to clean up
         should_run = false
-        sleep 5 # wait for telegraph to start if it's going to start
+        sleep 5 # wait for telegraf to start if it's going to start
         Process.kill("KILL", telegraf_pid)
       end
 

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -284,13 +284,15 @@ class ServerController < Pidly::Control
 
   # This is how you daemonize in ruby, preventing an orphaned inner process.
   def daemonize(&block)
-    fork do
+    temp_pid = fork do
       Process.setsid
       trap 'SIGHUP', 'IGNORE'
       fork do
         yield
       end
     end
+    # This prevents the short lived fork from sticking around as a zombie
+    Process.detach(temp_pid)
   end
 
   alias_method :clean, :clean!

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -232,7 +232,7 @@ class ServerController < Pidly::Control
 
   def run_telegraf
     instrumentald_pid = Process.pid
-    daemonize_block do
+    daemonize do
       $0 = "[Monitor] #{$0}"
       telegraf_pid = nil
       should_run = true
@@ -283,7 +283,7 @@ class ServerController < Pidly::Control
   end
 
   # This is how you daemonize in ruby, preventing an orphaned inner process.
-  def daemonize_block(&block)
+  def daemonize(&block)
     fork do
       Process.setsid
       trap 'SIGHUP', 'IGNORE'


### PR DESCRIPTION
This should prevent issues we were seeing on linux of instrumentald dying and leaving telegraf running. It sets up a monitor process that runs telegraf and watches the instrumentald process so when instrumentald exits the monitor process can kill telegraf, then exit itself.