### PR TITLE
Fixed -f references in startup scripts.

### DIFF
--- a/chef/instrumentald/templates/default/instrumentald.erb
+++ b/chef/instrumentald/templates/default/instrumentald.erb
@@ -18,7 +18,7 @@ PID="<%= @pid_file %>"
 LOG="<%= @log_file %>"
 SCRIPT_LOCATION="<%= @script_dir %>"
 USER_TO_RUN_AS="<%= @user %>"
-ARGS="-f ${CONFIG_FILE} -p ${PID} -l ${LOG} -s ${SCRIPT_LOCATION} -u ${USER_TO_RUN_AS} -t ${TMPDIR} <%= '-e' if @enable_scripts %>"
+ARGS="-c ${CONFIG_FILE} -p ${PID} -l ${LOG} -s ${SCRIPT_LOCATION} -u ${USER_TO_RUN_AS} -t ${TMPDIR} <%= '-e' if @enable_scripts %>"
 PROCESS="${DIRECTORY}instrumentald ${ARGS}"
 
 case "$1" in

--- a/debian/instrumentald
+++ b/debian/instrumentald
@@ -18,7 +18,7 @@ PID="${DIRECTORY}instrumentald.pid"
 LOG="${DIRECTORY}instrumentald.log"
 SCRIPT_LOCATION="${DIRECTORY}.instrumental_scripts"
 USER_TO_RUN_AS="nobody"
-ARGS="-f ${CONFIG_FILE} -p ${PID} -l ${LOG} -s ${SCRIPT_LOCATION} -u ${USER_TO_RUN_AS} -t ${TMPDIR}"
+ARGS="-c ${CONFIG_FILE} -p ${PID} -l ${LOG} -s ${SCRIPT_LOCATION} -u ${USER_TO_RUN_AS} -t ${TMPDIR}"
 PROCESS="${DIRECTORY}instrumentald ${ARGS}"
 
 case "$1" in

--- a/rpm/instrumentald
+++ b/rpm/instrumentald
@@ -18,7 +18,7 @@ PID="${DIRECTORY}instrumentald.pid"
 LOG="${DIRECTORY}instrumentald.log"
 SCRIPT_LOCATION="${DIRECTORY}.instrumental_scripts"
 USER_TO_RUN_AS="nobody"
-ARGS="-f ${CONFIG_FILE} -p ${PID} -l ${LOG} -s ${SCRIPT_LOCATION} -u ${USER_TO_RUN_AS} -t ${TMPDIR}"
+ARGS="-c ${CONFIG_FILE} -p ${PID} -l ${LOG} -s ${SCRIPT_LOCATION} -u ${USER_TO_RUN_AS} -t ${TMPDIR}"
 PROCESS="${DIRECTORY}instrumentald ${ARGS}"
 
 case "$1" in

--- a/systemd/instrumentald.service
+++ b/systemd/instrumentald.service
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/opt/instrumental-tools/instrumentald -f /etc/instrumentald.toml -p /opt/instrumental-tools/instrumentald.pid -l /opt/instrumental-tools/instrumentald.log -s /opt/instrumental-tools/.instrumental_scripts -t /opt/instrumental-tools/ foreground
+ExecStart=/opt/instrumental-tools/instrumentald -c /etc/instrumentald.toml -p /opt/instrumental-tools/instrumentald.pid -l /opt/instrumental-tools/instrumentald.log -s /opt/instrumental-tools/.instrumental_scripts -t /opt/instrumental-tools/ foreground
 
 TimeoutSec=60
 

--- a/win32/src/instrumental/InstrumentServerProcess.cs
+++ b/win32/src/instrumental/InstrumentServerProcess.cs
@@ -84,7 +84,7 @@ namespace Instrumental
 
     public void SetupProcess(string executablePath, string configPath, string hostname, bool scriptsEnabled, string scriptsDirectory){
       CleanupProcess();
-      string args                              = $"{RubyFlags()} \"{InstrumentServerScript(executablePath)}\" -f \"{configPath}\" -H \"{hostname}\"";
+      string args                              = $"{RubyFlags()} \"{InstrumentServerScript(executablePath)}\" -c \"{configPath}\" -H \"{hostname}\"";
       if(scriptsEnabled){
         args += $" -e -s \"{scriptsDirectory}\"";
       }


### PR DESCRIPTION
Installing the package and using the init.d scripts failed because we changed the -f option to -c, this fixes that.