### PR TITLE
Added rake package:release task to push all packages to Package Cloud.

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,22 +1,6 @@
 # Building instrumentald
 
-## The Gem
-
-Building the `instrumentald` gem can be done via:
-
-```
-rake gem
-```
-
-This will produce a .gem file suitable for release. As a shortcut for the RubyGems release process, you can issue the following command:
-
-```
-rake release
-```
-
-to push a new copy of the gem directly to RubyGems. This presumes you have the correct `rubygems_api_key` available in your system Gem config.
-
-## `deb`, `rpm` and `tgz` packages
+## Linux
 
 To build everything, use the following command:
 
@@ -40,34 +24,27 @@ rake package:linux-x86_64:package
 rake package:linux-x86_64:compress
 ```
 
-For Mac OS X:
-
-```
-rake package:osx:compress
-```
-
 `deb` and `rpm` packages should be pushed to PackageCloud. You will need to ensure you have the `package_cloud` gem installed (`bundle install` should install it for you - see the [PackageCloud instructions](https://packagecloud.io/docs#cli_install) otherwise). You will also need write credentials to PackageCloud available in `~/.packagecloud`; they will follow the format:
 
 ```
 {"url":"https://packagecloud.io","token":"YOUR PACKAGECLOUD API TOKEN"}
 ```
 
-You will need to install some things:
-
-```
-brew install gnu-tar --with-default-names
-brew install rpm
-```
-
 And then use the package_cloud gem to push our packages.  For example:
 
 ```
-package_cloud push expectedbehavior/instrumental/ubuntu/precise instrumentald_YOUR_VERSION_HERE_amd64.deb
+rake package:release
 ```
 
 On release, the tarball should be uploaded to the Github releases page and linked to from the main README.md.
 
-## `exe` packages
+## Mac OS X
+
+```
+rake package:osx:compress
+```
+
+## Windows
 
 In order to build the Windows installer, you'll need to have [NSIS](http://nsis.sourceforge.net/Main_Page) and [Mono](http://www.mono-project.com/) installed. If you're using Mac OS X, run the following commands:
 


### PR DESCRIPTION
This includes corresponding updates to BUILD.md along with some reorganization. It also changes the rake task name for individual packages from 'push' to 'release' to match package:release.

This also fixes what seemed to be an existing issue where before a package was pushed to Package Cloud we would yank a package of the same name to ensure there wasn't an existing package that would block the release. Apparently Package Cloud automatically changes the package name in some cases depending on the distro. This means the yank fails because the package in Package Cloud has a different name than the name we used to push it. In this PR you'll see some code to transform the yanking package name to match Package Cloud's name. It seems like there's probably a better way to do this, but not being super familiar with this whole packaging system I'm not sure what that way is. I'm willing to ride with this until we learn more about it and run into this again.