### PR TITLE
Make postgresql plugin work better

### DIFF
--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -798,20 +798,20 @@
   ##   withdbname boolean
   ##   tagvalue string (comma separated)
   ##   measurement string
-  <% server_part = server_url.split("@").last.split("?").first.strip %>
-  <% server_part = ".#{server_part}" unless server_part.empty? %>
   [[inputs.postgresql_extensible.query]]
     sqlquery="SELECT * FROM pg_stat_database WHERE datname"
     version=901
     withdbname=true
     tagvalue=""
-    measurement="postgresql<%= server_part %>"
+    measurement=""
   [[inputs.postgresql_extensible.query]]
     sqlquery="SELECT * FROM pg_stat_bgwriter"
     version=901
     withdbname=false
     tagvalue=""
-    measurement="postgresql<%= server_part %>"
+    measurement=""
+  [inputs.postgresql_extensible.tags]
+    server_name = <%= server_url.split("@").last.split("?").first.strip.inspect %>
 <% end %>
 
 # # Read metrics from one or many PowerDNS servers

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -798,6 +798,23 @@
   ##   withdbname boolean
   ##   tagvalue string (comma separated)
   ##   measurement string
+  fieldpass=[
+    "blk_read_time",
+    "blk_write_time",
+    "blks_read",
+    "checkpoint_sync_time",
+    "checkpoint_write_time",
+    "deadlocks",
+    "numbackends",
+    "temp_bytes",
+    "tup_deleted",
+    "tup_fetched",
+    "tup_inserted",
+    "tup_returned",
+    "tup_updated",
+    "xact_commit",
+    "xact_rollback"
+  ]
   [[inputs.postgresql_extensible.query]]
     sqlquery="SELECT * FROM pg_stat_database WHERE datname"
     version=901


### PR DESCRIPTION
Instead of complicated measurement overrides for postgres metric names, just use the built-in tagging system

This changes the order of metric parts from `postgresql.<servername>.<databasename>.<measure>` -> `postgresql.<databasename>.<servername>.<measure>`, which I think is probably better in a cluster situation anyway.

See #3 for the way it should have been done by me, and then #9 for how I did it, but shouldn't have.

The metric list is now:

```
blk_read_time
blk_write_time
blks_read
checkpoint_sync_time
checkpoint_write_time
deadlocks
numbackends
temp_bytes
tup_deleted
tup_fetched
tup_inserted
tup_returned
tup_updated
xact_commit
xact_rollback
```
