### PR TITLE
Fixed issue where stating the daemon twice resulted in printing an exception.

### DIFF
--- a/bin/instrumentald
+++ b/bin/instrumentald
@@ -226,12 +226,7 @@ end
 
 
 if running_as_daemon
-  begin
-    Timeout.timeout(1) do
-      Process.waitpid(controller.pid)
-    end
-  rescue Timeout::Error
-  end
+  sleep 1
   if !controller.running?
     raise "Failed to start process, see #{options[:log_location]}"
   end


### PR DESCRIPTION
This fixes #12 by switching away from Process.waitpid which raises if the pid isn't a child of the current process. The goal here was to quickly abort if the process didn't start. Unfortunately if you had already started instrumentald it would have daemonized and wouldn't be a child if the current process, meaning waitpid would fail. Sleeping for 1 second seems simpler overall.