### PR TITLE
Improve memcached metrics

### DIFF
--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -190,7 +190,7 @@ class ServerController < Pidly::Control
   def process_telegraf_config
     instrumental_api_key = configured_api_key
     redis_servers = config_file['redis']
-    memcached_servers = config_file['memcached']
+    memcached_servers = config_file['memcached'] || []
     postgresql_servers = config_file['postgresql'] || []
 
     File.open(telegraf_config_path, "w+") do |config|

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -519,18 +519,19 @@
 #   # campaign_id = ""
 
 
-# # Read metrics from one or many memcached servers
-<% if memcached_servers != nil %>
+# Read metrics from one or many memcached servers
+
+<% memcached_servers.each do |server_url| %>
+  <% puts server_url %>
 [[inputs.memcached]]
-<% else %>
-# [[inputs.memcached]]
-<% end %>
-#   ## An array of address to gather stats about. Specify an ip on hostname
-#   ## with optional port. ie localhost, 10.0.0.1:11211, etc.
-#   servers = ["localhost:11211"]
-#   # unix_sockets = ["/var/run/memcached.sock"]
-<% if memcached_servers != nil %>
-  servers = <%= memcached_servers %>
+  tagexclude = ["server", "host"]
+  ## An array of address to gather stats about. Specify an ip on hostname
+  ## with optional port. ie localhost, 10.0.0.1:11211, etc.
+  servers = [<%= server_url.inspect %>]
+  # unix_sockets = ["/var/run/memcached.sock"]
+
+  [inputs.memcached.tags]
+    server_name = <%= server_url.split(":").first.strip.inspect %>
 <% end %>
 
 # # Telegraf plugin for gathering metrics from N Mesos masters


### PR DESCRIPTION
work on memcached servers as an array that each have their own inputs setup, and then tag them per server name instead of relying on built-in host and server tags, because those are just garbage for us. The metrics we get out look like this (given a server setup like `memcached = ["localhost:11211"]` in instrumental.toml):

```
gauge memcached.localhost.cas_hits 0 1468532820
gauge memcached.localhost.cas_misses 0 1468532820
gauge memcached.localhost.cmd_set 0 1468532820
gauge memcached.localhost.connection_structures 11 1468532820
gauge memcached.localhost.get_hits 0 1468532820
gauge memcached.localhost.get_misses 0 1468532820
gauge memcached.localhost.limit_maxbytes 67108864 1468532820
gauge memcached.localhost.total_connections 28 1468532820
gauge memcached.localhost.bytes_read 126 1468532820
gauge memcached.localhost.bytes_written 19319 1468532820
gauge memcached.localhost.conn_yields 0 1468532820
gauge memcached.localhost.decr_hits 0 1468532820
gauge memcached.localhost.decr_misses 0 1468532820
gauge memcached.localhost.delete_hits 0 1468532820
gauge memcached.localhost.incr_misses 0 1468532820
gauge memcached.localhost.total_items 0 1468532820
gauge memcached.localhost.bytes 0 1468532820
gauge memcached.localhost.cmd_get 0 1468532820
gauge memcached.localhost.evictions 0 1468532820
gauge memcached.localhost.incr_hits 0 1468532820
gauge memcached.localhost.threads 4 1468532820
gauge memcached.localhost.uptime 2704849 1468532820
gauge memcached.localhost.curr_connections 10 1468532820
gauge memcached.localhost.curr_items 0 1468532820
gauge memcached.localhost.delete_misses 0 1468532820
```