### PR TITLE
Updated system metric names to be prefixed with 'system.'.

### DIFF
--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -155,7 +155,7 @@
   ## Look at the output template for more info.
   name_override = "system"
   [inputs.mem.tags]
-    system_measurement_tag = "mem"
+    system_measurement_tag = "memory"
 
 
 # Get the number of processes and group them by status
@@ -699,7 +699,7 @@
   ## Look at the output template for more info.
   name_override = "system"
   [inputs.net.tags]
-    system_measurement_tag = "net"
+    system_measurement_tag = "network"
 
 
 # # TCP or UDP 'ping' given url and collect response time in seconds

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -73,7 +73,7 @@
   prefix = ""
   ## Stats output template (Graphite formatting)
   ## see https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md#graphite
-  template = "host.measurement.tags.field"
+  template = "measurement.host.system_measurement_tag.tags.field"
   ## Timeout in seconds to connect
   timeout = "2s"
   ## Debug true - Print communcation to Instrumental
@@ -92,6 +92,12 @@
   ## Comment this line if you want the raw CPU time metrics
   fielddrop = ["time_*"]
 
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.cpu.tags]
+    system_measurement_tag = "cpu"
 
 # Read metrics about disk usage by mount point
 [[inputs.disk]]
@@ -103,6 +109,13 @@
   ## present on /run, /var/run, /dev/shm or /dev).
   ignore_fs = ["tmpfs", "devtmpfs"]
 
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.disk.tags]
+    system_measurement_tag = "disk"
+
 
 # Read metrics about disk IO by device
 [[inputs.diskio]]
@@ -113,30 +126,72 @@
   ## Uncomment the following line if you do not need disk serial numbers.
   # skip_serial_number = true
 
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.diskio.tags]
+    system_measurement_tag = "diskio"
+
 
 # Get kernel statistics from /proc/stat
 [[inputs.kernel]]
   # no configuration
+
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.kernel.tags]
+    system_measurement_tag = "kernel"
 
 
 # Read metrics about memory usage
 [[inputs.mem]]
   # no configuration
 
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.mem.tags]
+    system_measurement_tag = "mem"
+
 
 # Get the number of processes and group them by status
 [[inputs.processes]]
   # no configuration
+
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.processes.tags]
+    system_measurement_tag = "processes"
 
 
 # Read metrics about swap memory usage
 [[inputs.swap]]
   # no configuration
 
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.swap.tags]
+    system_measurement_tag = "swap"
+
 
 # Read metrics about system load & uptime
 [[inputs.system]]
   # no configuration
+
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.system.tags]
+    system_measurement_tag = "system"
 
 
 # # Read stats from an aerospike server
@@ -632,6 +687,13 @@
 #   ## regardless of status.
 #   ##
 #   # interfaces = ["eth0"]
+
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.net.tags]
+    system_measurement_tag = "net"
 
 
 # # TCP or UDP 'ping' given url and collect response time in seconds


### PR DESCRIPTION
This overrides the "measurement" name for the system type metrics, and adds a
new tag to the output template. This allows us to retain what was the old
measurement name in it's old place by setting it explicitly using the new tag.

So for system metrics we have:
```
system.<host>.<explicitly_set_tag_thats_that_same_as_measurement>.<tags>.<field>
```
or:
```
system.localhost.cpu.cpu-totals.usage_user
```

For non system metrics:
```
<measurement>.<host>.<tag_that_isnt_set_so_disappears>.<tags>.<field>
```
or:
```
mysql.db-001.connections
```