### PR TITLE
Let me take you to… Redistown

### DIFF
--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -189,7 +189,7 @@ class ServerController < Pidly::Control
 
   def process_telegraf_config
     instrumental_api_key = configured_api_key
-    redis_servers = config_file['redis']
+    redis_servers = config_file['redis'] || []
     memcached_servers = config_file['memcached'] || []
     postgresql_servers = config_file['postgresql'] || []
 

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -626,13 +626,13 @@
 <% end %>
 
 
-# # Read metrics about network interface usage
+# Read metrics about network interface usage
 [[inputs.net]]
-#   ## By default, telegraf gathers stats from any up interface (excluding loopback)
-#   ## Setting interfaces will tell it to gather these explicit interfaces,
-#   ## regardless of status.
-#   ##
-#   # interfaces = ["eth0"]
+  ## By default, telegraf gathers stats from any up interface (excluding loopback)
+  ## Setting interfaces will tell it to gather these explicit interfaces,
+  ## regardless of status.
+  ##
+  # interfaces = ["eth0"]
 
 
 # # TCP or UDP 'ping' given url and collect response time in seconds

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -972,7 +972,7 @@
 
 
 <% redis_servers.each do |server_url| %>
-# # Read metrics from one or many redis servers
+# Read metrics from one or many redis servers
 [[inputs.redis]]
   ## specify servers via a url matching:
   ##  [protocol://][:password]@address[:port]
@@ -985,6 +985,34 @@
   name_override="redis"
   servers = [<%= server_url.inspect %>]
   tagexclude = ["host", "port"]
+  # Fields to feed out that are important. There are two distinct kinds of metric,
+  # but TOML doesn't allow for in-array comments, so:
+  # Redis Instance-Wide begin at "clients"
+  # DB-specific begin at "avg_ttl"
+  fieldpass=[
+    "clients",
+    "connected_slaves",
+    "evicted_keys",
+    "expired_keys",
+    "instantaneous_input_kbps",
+    "instantaneous_ops_per_sec",
+    "instantaneous_output_kbps",
+    "keyspace_hits",
+    "keyspace_misses",
+    "pubsub_channels",
+    "pubsub_patterns",
+    "repl_backlog_histlen",
+    "sync_full",
+    "sync_partial_err",
+    "sync_partial_ok",
+    "used_cpu_sys",
+    "used_cpu_user",
+    "used_memory",
+    "used_memory_rss",
+    "avg_ttl",
+    "expires",
+    "keys"
+  ]
 <% end %>
 
 # # Read metrics from one or many RethinkDB servers

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -892,12 +892,9 @@
 #   urls = ["http://localhost:8080/_raindrops"]
 
 
+<% redis_servers.each do |server_url| %>
 # # Read metrics from one or many redis servers
-<% if redis_servers != nil %>
 [[inputs.redis]]
-<% else %>
-# [[inputs.redis]]
-<% end %>
   ## specify servers via a url matching:
   ##  [protocol://][:password]@address[:port]
   ##  e.g.
@@ -906,10 +903,9 @@
   ##
   ## If no servers are specified, then localhost is used as the host.
   ## If no port is specified, 6379 is used
-<% if redis_servers != nil %>
-  servers = <%= redis_servers %>
+  servers = [<%= server_url.inspect %>]
+  tagexclude = ["host", "port"]
 <% end %>
-
 
 # # Read metrics from one or many RethinkDB servers
 # [[inputs.rethinkdb]]

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -903,6 +903,7 @@
   ##
   ## If no servers are specified, then localhost is used as the host.
   ## If no port is specified, 6379 is used
+  name_override="redis"
   servers = [<%= server_url.inspect %>]
   tagexclude = ["host", "port"]
 <% end %>


### PR DESCRIPTION
* work like other inputs in having multiple servers be a set of configs instead of one config
* make the per-db metrics live inside the same top level metric naming scheme as the other redis metrics
* don't report host and port as part of the metric name