### PR TITLE
add mongodb configuration

### DIFF
--- a/conf/instrumental.toml
+++ b/conf/instrumental.toml
@@ -5,5 +5,6 @@
 api_key = "YOUR_API_KEY"
 # redis = ["tcp://localhost:6379"]
 # memcached = ["localhost:11211"]
+# mongodb = ["localhost:27017"]
 # mysql = ["root@tcp(127.0.0.1:3306)/"]
 # postgresql = ["postgres://postgres@localhost?sslmode=disable"]

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -190,8 +190,9 @@ class ServerController < Pidly::Control
   def process_telegraf_config
     instrumental_api_key = configured_api_key
     redis_servers = config_file['redis']
-    memcached_servers = config_file['memcached'] || []
-    postgresql_servers = config_file['postgresql'] || []
+    memcached_servers  = Array(config_file['memcached'])
+    postgresql_servers = Array(config_file['postgresql'])
+    mongodb_servers    = Array(config_file['mongodb'])
 
     File.open(telegraf_config_path, "w+") do |config|
       result = ERB.new(File.read(telegraf_template_config_path)).result(binding)

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -553,14 +553,19 @@
 #   ]
 
 
+<% (config_file['mongodb'] || []).each do |server_url| %>
 # # Read metrics from one or many MongoDB servers
-# [[inputs.mongodb]]
+[[inputs.mongodb]]
 #   ## An array of URI to gather stats about. Specify an ip or hostname
 #   ## with optional port add password. ie,
 #   ##   mongodb://user:auth_key@10.10.3.30:27017,
 #   ##   mongodb://10.10.3.33:18832,
 #   ##   10.0.0.1:10000, etc.
-#   servers = ["127.0.0.1:27017"]
+  servers = <%= [server_url] %>
+  tagexclude = ["host"]
+  [inputs.mongodb.tags]
+    server_name = "<%= server_url.split(":").first %>"
+<% end %>
 
 
 <% (config_file['mysql'] || []).each do |server_url| %>

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -553,7 +553,7 @@
 #   ]
 
 
-<% (config_file['mongodb'] || []).each do |server_url| %>
+<% mongodb_servers.each do |server_url| %>
 # # Read metrics from one or many MongoDB servers
 [[inputs.mongodb]]
 #   ## An array of URI to gather stats about. Specify an ip or hostname


### PR DESCRIPTION
Based heavily on #3!

Enables mongodb functionality.  As mongo's defaults are mostly reasonable, this is pretty straightforward.  Due to the chattiness of per-db stats, I have not added an option to enable those at this time.

Outputs stats like [this](https://instrumentalapp.com/graphs/new?project_id=1067&graph[metrics][]=mongodb.localhost.net_in_bytes&graph[metrics][]=mongodb.localhost.net_out_bytes) (mongodb.localhost.net_in, for example).