### PR TITLE
Added more debug output which includes tags.

### DIFF
--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -79,6 +79,18 @@
   ## Debug true - Print communcation to Instrumental
   debug = <%= opts[:debug] %>
 
+<% if opts[:debug] %>
+# Send telegraf metrics to file(s)
+[[outputs.file]]
+  ## Files to write to, "stdout" is a specially handled file.
+  files = ["stdout"]
+  ## Data format to output.
+  ## Each data format has it's own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
+  data_format = "influx"
+<% end %>
+
 ###############################################################################
 #                            INPUT PLUGINS                                    #
 ###############################################################################


### PR DESCRIPTION
When you run with `--debug` you'll now see output like this as well:
```
system,cpu=cpu6,host=charlie_test7,system_measurement_tag=cpu usage_guest=0,usage_guest_nice=0,usage_idle=86.4,usage_iowait=0,usage_irq=0,usage_nice=0,usage_softirq=0,usage_steal=0,usage_system=5.2,usage_user=8.4 1469560330000000000
```

This makes it way easier to tell what tags you need to exclude in order to get the metric name you want.