### PR TITLE
Add Nginx monitoring to instrumentald

### DIFF
--- a/conf/instrumental.toml
+++ b/conf/instrumental.toml
@@ -2,9 +2,11 @@
 # remove the # from the beginning of the following line to have instrumentald
 # start sending metrics to your account.
 
-api_key = "YOUR_API_KEY"
+api_key = "2b1145f7b4004ea8121250abe4a5cb89"
+# api_key = "YOUR_API_KEY"
 # redis = ["tcp://localhost:6379"]
 # memcached = ["localhost:11211"]
 # mongodb = ["localhost:27017"]
 # mysql = ["root@tcp(127.0.0.1:3306)/"]
+# nginx = ["http://localhost:80/status"]
 # postgresql = ["postgres://postgres@localhost?sslmode=disable"]

--- a/conf/instrumental.toml
+++ b/conf/instrumental.toml
@@ -2,8 +2,7 @@
 # remove the # from the beginning of the following line to have instrumentald
 # start sending metrics to your account.
 
-api_key = "2b1145f7b4004ea8121250abe4a5cb89"
-# api_key = "YOUR_API_KEY"
+api_key = "YOUR_API_KEY"
 # redis = ["tcp://localhost:6379"]
 # memcached = ["localhost:11211"]
 # mongodb = ["localhost:27017"]

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -192,6 +192,7 @@ class ServerController < Pidly::Control
     redis_servers      = Array(config_file['redis'])
     mysql_servers      = Array(config_file['mysql'])
     memcached_servers  = Array(config_file['memcached'])
+    nginx_servers      = Array(config_file['nginx'])
     postgresql_servers = Array(config_file['postgresql'])
     mongodb_servers    = Array(config_file['mongodb'])
 

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -25,7 +25,7 @@
 # Configuration for telegraf agent
 [agent]
   ## Default data collection interval for all inputs
-  interval = "<%= opts[:report_interval] %>s"
+  interval = "5s" # "<%= opts[:report_interval] %>s"
   ## Rounds collection interval to 'interval'
   ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
   round_interval = true
@@ -46,7 +46,7 @@
 
   ## Default flushing interval for all outputs. You shouldn't set this below
   ## interval. Maximum flush_interval will be flush_interval + flush_jitter
-  flush_interval = "<%= opts[:report_interval] %>s"
+  flush_interval = "5s" # "<%= opts[:report_interval] %>s"
   ## Jitter the flush interval by a random amount. This is primarily to avoid
   ## large write spikes for users running a large number of telegraf instances.
   ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
@@ -95,115 +95,115 @@
 #                            INPUT PLUGINS                                    #
 ###############################################################################
 
-# Read metrics about cpu usage
-[[inputs.cpu]]
-  ## Whether to report per-cpu stats or not
-  percpu = false
-  ## Whether to report total system cpu stats or not
-  totalcpu = true
-  ## Comment this line if you want the raw CPU time metrics
-  fielddrop = ["time_*"]
+# # Read metrics about cpu usage
+# [[inputs.cpu]]
+#   ## Whether to report per-cpu stats or not
+#   percpu = false
+#   ## Whether to report total system cpu stats or not
+#   totalcpu = true
+#   ## Comment this line if you want the raw CPU time metrics
+#   fielddrop = ["time_*"]
 
-  ## These lines fix the system metric names to basically be
-  ## system.<host>.<measurement>.<field>
-  ## Look at the output template for more info.
-  name_override = "system"
-  [inputs.cpu.tags]
-    system_measurement_tag = "cpu"
+#   ## These lines fix the system metric names to basically be
+#   ## system.<host>.<measurement>.<field>
+#   ## Look at the output template for more info.
+#   name_override = "system"
+#   [inputs.cpu.tags]
+#     system_measurement_tag = "cpu"
 
-# Read metrics about disk usage by mount point
-[[inputs.disk]]
-  ## By default, telegraf gather stats for all mountpoints.
-  ## Setting mountpoints will restrict the stats to the specified mountpoints.
-  # mount_points = ["/"]
+# # Read metrics about disk usage by mount point
+# [[inputs.disk]]
+#   ## By default, telegraf gather stats for all mountpoints.
+#   ## Setting mountpoints will restrict the stats to the specified mountpoints.
+#   # mount_points = ["/"]
 
-  ## Ignore some mountpoints by filesystem type. For example (dev)tmpfs (usually
-  ## present on /run, /var/run, /dev/shm or /dev).
-  ignore_fs = ["tmpfs", "devtmpfs"]
+#   ## Ignore some mountpoints by filesystem type. For example (dev)tmpfs (usually
+#   ## present on /run, /var/run, /dev/shm or /dev).
+#   ignore_fs = ["tmpfs", "devtmpfs"]
 
-  ## These lines fix the system metric names to basically be
-  ## system.<host>.<measurement>.<field>
-  ## Look at the output template for more info.
-  name_override = "system"
-  [inputs.disk.tags]
-    system_measurement_tag = "disk"
-
-
-# Read metrics about disk IO by device
-[[inputs.diskio]]
-  ## By default, telegraf will gather stats for all devices including
-  ## disk partitions.
-  ## Setting devices will restrict the stats to the specified devices.
-  # devices = ["sda", "sdb"]
-  ## Uncomment the following line if you do not need disk serial numbers.
-  # skip_serial_number = true
-
-  ## These lines fix the system metric names to basically be
-  ## system.<host>.<measurement>.<field>
-  ## Look at the output template for more info.
-  name_override = "system"
-  [inputs.diskio.tags]
-    system_measurement_tag = "diskio"
+#   ## These lines fix the system metric names to basically be
+#   ## system.<host>.<measurement>.<field>
+#   ## Look at the output template for more info.
+#   name_override = "system"
+#   [inputs.disk.tags]
+#     system_measurement_tag = "disk"
 
 
-# Get kernel statistics from /proc/stat
-[[inputs.kernel]]
-  # no configuration
+# # Read metrics about disk IO by device
+# [[inputs.diskio]]
+#   ## By default, telegraf will gather stats for all devices including
+#   ## disk partitions.
+#   ## Setting devices will restrict the stats to the specified devices.
+#   # devices = ["sda", "sdb"]
+#   ## Uncomment the following line if you do not need disk serial numbers.
+#   # skip_serial_number = true
 
-  ## These lines fix the system metric names to basically be
-  ## system.<host>.<measurement>.<field>
-  ## Look at the output template for more info.
-  name_override = "system"
-  [inputs.kernel.tags]
-    system_measurement_tag = "kernel"
-
-
-# Read metrics about memory usage
-[[inputs.mem]]
-  # no configuration
-
-  ## These lines fix the system metric names to basically be
-  ## system.<host>.<measurement>.<field>
-  ## Look at the output template for more info.
-  name_override = "system"
-  [inputs.mem.tags]
-    system_measurement_tag = "memory"
+#   ## These lines fix the system metric names to basically be
+#   ## system.<host>.<measurement>.<field>
+#   ## Look at the output template for more info.
+#   name_override = "system"
+#   [inputs.diskio.tags]
+#     system_measurement_tag = "diskio"
 
 
-# Get the number of processes and group them by status
-[[inputs.processes]]
-  # no configuration
+# # Get kernel statistics from /proc/stat
+# [[inputs.kernel]]
+#   # no configuration
 
-  ## These lines fix the system metric names to basically be
-  ## system.<host>.<measurement>.<field>
-  ## Look at the output template for more info.
-  name_override = "system"
-  [inputs.processes.tags]
-    system_measurement_tag = "processes"
-
-
-# Read metrics about swap memory usage
-[[inputs.swap]]
-  # no configuration
-
-  ## These lines fix the system metric names to basically be
-  ## system.<host>.<measurement>.<field>
-  ## Look at the output template for more info.
-  name_override = "system"
-  [inputs.swap.tags]
-    system_measurement_tag = "swap"
+#   ## These lines fix the system metric names to basically be
+#   ## system.<host>.<measurement>.<field>
+#   ## Look at the output template for more info.
+#   name_override = "system"
+#   [inputs.kernel.tags]
+#     system_measurement_tag = "kernel"
 
 
-# Read metrics about system load & uptime
-[[inputs.system]]
-  # no configuration
+# # Read metrics about memory usage
+# [[inputs.mem]]
+#   # no configuration
 
-  ## These lines fix the system metric names to basically be
-  ## system.<host>.<measurement>.<field>
-  ## Look at the output template for more info.
-  name_override = "system"
-  [inputs.system.tags]
-    system_measurement_tag = "system"
+#   ## These lines fix the system metric names to basically be
+#   ## system.<host>.<measurement>.<field>
+#   ## Look at the output template for more info.
+#   name_override = "system"
+#   [inputs.mem.tags]
+#     system_measurement_tag = "memory"
+
+
+# # Get the number of processes and group them by status
+# [[inputs.processes]]
+#   # no configuration
+
+#   ## These lines fix the system metric names to basically be
+#   ## system.<host>.<measurement>.<field>
+#   ## Look at the output template for more info.
+#   name_override = "system"
+#   [inputs.processes.tags]
+#     system_measurement_tag = "processes"
+
+
+# # Read metrics about swap memory usage
+# [[inputs.swap]]
+#   # no configuration
+
+#   ## These lines fix the system metric names to basically be
+#   ## system.<host>.<measurement>.<field>
+#   ## Look at the output template for more info.
+#   name_override = "system"
+#   [inputs.swap.tags]
+#     system_measurement_tag = "swap"
+
+
+# # Read metrics about system load & uptime
+# [[inputs.system]]
+#   # no configuration
+
+#   ## These lines fix the system metric names to basically be
+#   ## system.<host>.<measurement>.<field>
+#   ## Look at the output template for more info.
+#   name_override = "system"
+#   [inputs.system.tags]
+#     system_measurement_tag = "system"
 
 
 # # Read stats from an aerospike server
@@ -719,20 +719,20 @@
 <% end %>
 
 
-# Read metrics about network interface usage
-[[inputs.net]]
-  ## By default, telegraf gathers stats from any up interface (excluding loopback)
-  ## Setting interfaces will tell it to gather these explicit interfaces,
-  ## regardless of status.
-  ##
-  # interfaces = ["eth0"]
+# # Read metrics about network interface usage
+# [[inputs.net]]
+#   ## By default, telegraf gathers stats from any up interface (excluding loopback)
+#   ## Setting interfaces will tell it to gather these explicit interfaces,
+#   ## regardless of status.
+#   ##
+#   # interfaces = ["eth0"]
 
-  ## These lines fix the system metric names to basically be
-  ## system.<host>.<measurement>.<field>
-  ## Look at the output template for more info.
-  name_override = "system"
-  [inputs.net.tags]
-    system_measurement_tag = "network"
+#   ## These lines fix the system metric names to basically be
+#   ## system.<host>.<measurement>.<field>
+#   ## Look at the output template for more info.
+#   name_override = "system"
+#   [inputs.net.tags]
+#     system_measurement_tag = "network"
 
 
 # # TCP or UDP 'ping' given url and collect response time in seconds
@@ -756,11 +756,13 @@
 #   # no configuration
 
 
-# # Read Nginx's basic status information (ngx_http_stub_status_module)
-# [[inputs.nginx]]
-#   ## An array of Nginx stub_status URI to gather stats.
-#   urls = ["http://localhost/status"]
-
+<% nginx_servers.each do |server_url| %>
+# Read Nginx's basic status information (ngx_http_stub_status_module)
+[[inputs.nginx]]
+  ## An array of Nginx stub_status URI to gather stats.
+  urls = [<%= server_url.inspect %>]
+  tagexclude = ["host", "port"]
+<% end %>
 
 # # Read NSQ topic and channel statistics.
 # [[inputs.nsq]]

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -25,7 +25,7 @@
 # Configuration for telegraf agent
 [agent]
   ## Default data collection interval for all inputs
-  interval = "5s" # "<%= opts[:report_interval] %>s"
+  interval = "<%= opts[:report_interval] %>s"
   ## Rounds collection interval to 'interval'
   ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
   round_interval = true
@@ -46,7 +46,7 @@
 
   ## Default flushing interval for all outputs. You shouldn't set this below
   ## interval. Maximum flush_interval will be flush_interval + flush_jitter
-  flush_interval = "5s" # "<%= opts[:report_interval] %>s"
+  flush_interval = "<%= opts[:report_interval] %>s"
   ## Jitter the flush interval by a random amount. This is primarily to avoid
   ## large write spikes for users running a large number of telegraf instances.
   ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
@@ -95,115 +95,115 @@
 #                            INPUT PLUGINS                                    #
 ###############################################################################
 
-# # Read metrics about cpu usage
-# [[inputs.cpu]]
-#   ## Whether to report per-cpu stats or not
-#   percpu = false
-#   ## Whether to report total system cpu stats or not
-#   totalcpu = true
-#   ## Comment this line if you want the raw CPU time metrics
-#   fielddrop = ["time_*"]
+# Read metrics about cpu usage
+[[inputs.cpu]]
+  ## Whether to report per-cpu stats or not
+  percpu = false
+  ## Whether to report total system cpu stats or not
+  totalcpu = true
+  ## Comment this line if you want the raw CPU time metrics
+  fielddrop = ["time_*"]
 
-#   ## These lines fix the system metric names to basically be
-#   ## system.<host>.<measurement>.<field>
-#   ## Look at the output template for more info.
-#   name_override = "system"
-#   [inputs.cpu.tags]
-#     system_measurement_tag = "cpu"
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.cpu.tags]
+    system_measurement_tag = "cpu"
 
-# # Read metrics about disk usage by mount point
-# [[inputs.disk]]
-#   ## By default, telegraf gather stats for all mountpoints.
-#   ## Setting mountpoints will restrict the stats to the specified mountpoints.
-#   # mount_points = ["/"]
+# Read metrics about disk usage by mount point
+[[inputs.disk]]
+  ## By default, telegraf gather stats for all mountpoints.
+  ## Setting mountpoints will restrict the stats to the specified mountpoints.
+  # mount_points = ["/"]
 
-#   ## Ignore some mountpoints by filesystem type. For example (dev)tmpfs (usually
-#   ## present on /run, /var/run, /dev/shm or /dev).
-#   ignore_fs = ["tmpfs", "devtmpfs"]
+  ## Ignore some mountpoints by filesystem type. For example (dev)tmpfs (usually
+  ## present on /run, /var/run, /dev/shm or /dev).
+  ignore_fs = ["tmpfs", "devtmpfs"]
 
-#   ## These lines fix the system metric names to basically be
-#   ## system.<host>.<measurement>.<field>
-#   ## Look at the output template for more info.
-#   name_override = "system"
-#   [inputs.disk.tags]
-#     system_measurement_tag = "disk"
-
-
-# # Read metrics about disk IO by device
-# [[inputs.diskio]]
-#   ## By default, telegraf will gather stats for all devices including
-#   ## disk partitions.
-#   ## Setting devices will restrict the stats to the specified devices.
-#   # devices = ["sda", "sdb"]
-#   ## Uncomment the following line if you do not need disk serial numbers.
-#   # skip_serial_number = true
-
-#   ## These lines fix the system metric names to basically be
-#   ## system.<host>.<measurement>.<field>
-#   ## Look at the output template for more info.
-#   name_override = "system"
-#   [inputs.diskio.tags]
-#     system_measurement_tag = "diskio"
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.disk.tags]
+    system_measurement_tag = "disk"
 
 
-# # Get kernel statistics from /proc/stat
-# [[inputs.kernel]]
-#   # no configuration
+# Read metrics about disk IO by device
+[[inputs.diskio]]
+  ## By default, telegraf will gather stats for all devices including
+  ## disk partitions.
+  ## Setting devices will restrict the stats to the specified devices.
+  # devices = ["sda", "sdb"]
+  ## Uncomment the following line if you do not need disk serial numbers.
+  # skip_serial_number = true
 
-#   ## These lines fix the system metric names to basically be
-#   ## system.<host>.<measurement>.<field>
-#   ## Look at the output template for more info.
-#   name_override = "system"
-#   [inputs.kernel.tags]
-#     system_measurement_tag = "kernel"
-
-
-# # Read metrics about memory usage
-# [[inputs.mem]]
-#   # no configuration
-
-#   ## These lines fix the system metric names to basically be
-#   ## system.<host>.<measurement>.<field>
-#   ## Look at the output template for more info.
-#   name_override = "system"
-#   [inputs.mem.tags]
-#     system_measurement_tag = "memory"
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.diskio.tags]
+    system_measurement_tag = "diskio"
 
 
-# # Get the number of processes and group them by status
-# [[inputs.processes]]
-#   # no configuration
+# Get kernel statistics from /proc/stat
+[[inputs.kernel]]
+  # no configuration
 
-#   ## These lines fix the system metric names to basically be
-#   ## system.<host>.<measurement>.<field>
-#   ## Look at the output template for more info.
-#   name_override = "system"
-#   [inputs.processes.tags]
-#     system_measurement_tag = "processes"
-
-
-# # Read metrics about swap memory usage
-# [[inputs.swap]]
-#   # no configuration
-
-#   ## These lines fix the system metric names to basically be
-#   ## system.<host>.<measurement>.<field>
-#   ## Look at the output template for more info.
-#   name_override = "system"
-#   [inputs.swap.tags]
-#     system_measurement_tag = "swap"
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.kernel.tags]
+    system_measurement_tag = "kernel"
 
 
-# # Read metrics about system load & uptime
-# [[inputs.system]]
-#   # no configuration
+# Read metrics about memory usage
+[[inputs.mem]]
+  # no configuration
 
-#   ## These lines fix the system metric names to basically be
-#   ## system.<host>.<measurement>.<field>
-#   ## Look at the output template for more info.
-#   name_override = "system"
-#   [inputs.system.tags]
-#     system_measurement_tag = "system"
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.mem.tags]
+    system_measurement_tag = "memory"
+
+
+# Get the number of processes and group them by status
+[[inputs.processes]]
+  # no configuration
+
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.processes.tags]
+    system_measurement_tag = "processes"
+
+
+# Read metrics about swap memory usage
+[[inputs.swap]]
+  # no configuration
+
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.swap.tags]
+    system_measurement_tag = "swap"
+
+
+# Read metrics about system load & uptime
+[[inputs.system]]
+  # no configuration
+
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.system.tags]
+    system_measurement_tag = "system"
 
 
 # # Read stats from an aerospike server
@@ -719,20 +719,20 @@
 <% end %>
 
 
-# # Read metrics about network interface usage
-# [[inputs.net]]
-#   ## By default, telegraf gathers stats from any up interface (excluding loopback)
-#   ## Setting interfaces will tell it to gather these explicit interfaces,
-#   ## regardless of status.
-#   ##
-#   # interfaces = ["eth0"]
+# Read metrics about network interface usage
+[[inputs.net]]
+  ## By default, telegraf gathers stats from any up interface (excluding loopback)
+  ## Setting interfaces will tell it to gather these explicit interfaces,
+  ## regardless of status.
+  ##
+  # interfaces = ["eth0"]
 
-#   ## These lines fix the system metric names to basically be
-#   ## system.<host>.<measurement>.<field>
-#   ## Look at the output template for more info.
-#   name_override = "system"
-#   [inputs.net.tags]
-#     system_measurement_tag = "network"
+  ## These lines fix the system metric names to basically be
+  ## system.<host>.<measurement>.<field>
+  ## Look at the output template for more info.
+  name_override = "system"
+  [inputs.net.tags]
+    system_measurement_tag = "network"
 
 
 # # TCP or UDP 'ping' given url and collect response time in seconds


### PR DESCRIPTION
Straight from [the source](http://nginx.org/en/docs/http/ngx_http_stub_status_module.html):

```
Active connections
    The current number of active client connections including Waiting connections. 
accepts
    The total number of accepted client connections. 
handled
    The total number of handled connections. Generally, the parameter value is the same as accepts unless some resource limits have been reached (for example, the worker_connections limit). 
requests
    The total number of client requests. 
Reading
    The current number of connections where nginx is reading the request header. 
Writing
    The current number of connections where nginx is writing the response back to the client. 
Waiting
    The current number of idle client connections waiting for a request. 
```