### PR TITLE
Make Chef/Puppet tests (via kitchen) work better

### DIFF
--- a/chef/.kitchen.yml
+++ b/chef/.kitchen.yml
@@ -16,7 +16,8 @@ platforms:
   # ubuntu 16 works differently, and this doesn't work currently
   # - name: ubuntu-16.04
   - name: centos-6.7
-  - name: "d11wtq/gentoo"
+  # gentoo is probably not a good choice for servers, and would take some more effort to make work
+  # - name: "d11wtq/gentoo"
   # windows 12 has changed significantly since the first rodeo,
   # and this doesn't work currently
   # - name: windows-2012r2

--- a/chef/instrumentald/recipes/default.rb
+++ b/chef/instrumentald/recipes/default.rb
@@ -34,15 +34,6 @@ package_destination = ::File.join(dest_dir, file_name)
 case node["platform_family"]
 when "debian", "rhel", "fedora"
 
-  template conf_file do
-    source "instrumentald.toml.erb"
-    mode   "0440"
-    owner  "nobody"
-    variables(
-      :api_key => node[:instrumental][:api_key]
-    )
-  end
-
   if node[:instrumental][:use_local]
     package "instrumentald" do
       action :install

--- a/puppet/.kitchen.yml
+++ b/puppet/.kitchen.yml
@@ -1,7 +1,6 @@
 ---
 driver:
   name: vagrant
-  provider: vmware_fusion
 
 provisioner:
   name: puppet_apply
@@ -14,12 +13,12 @@ platforms:
     driver_plugin: vagrant
     driver_config:
       box: nocm_ubuntu-12.04
-      box_url: https://atlas.hashicorp.com/puppetlabs/boxes/ubuntu-12.04-64-nocm/versions/1.0.1/providers/vmware_fusion.box
+      box_url: https://atlas.hashicorp.com/puppetlabs/boxes/ubuntu-12.04-64-nocm/versions/1.0.1/providers/virtualbox.box
   - name: nocm_centos-6.6
     driver_plugin: vagrant
     driver_config:
       box: nocm_centos-6.6
-      box_url: https://atlas.hashicorp.com/puppetlabs/boxes/centos-6.6-64-nocm/versions/1.0.1/providers/vmware_fusion.box
+      box_url: https://atlas.hashicorp.com/puppetlabs/boxes/centos-6.6-64-nocm/versions/1.0.1/providers/virtualbox.box
 
 suites:
   - name: default

--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -1,4 +1,4 @@
 forge "https://forgeapi.puppetlabs.com"
 
 mod "computology-packagecloud"
-mod "instrumentald", path: "instrumentald"
+mod "expectedbehavior-instrumentald", path: "instrumentald"

--- a/puppet/Puppetfile.lock
+++ b/puppet/Puppetfile.lock
@@ -1,17 +1,17 @@
 FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
-    computology-packagecloud (0.2.10)
+    computology-packagecloud (0.3.1)
       puppetlabs-stdlib (>= 0)
-    puppetlabs-stdlib (4.6.0)
+    puppetlabs-stdlib (4.12.0)
 
 PATH
-  remote: instrumental_tools
+  remote: instrumentald
   specs:
-    instrumental_tools (0.0.1)
-      computology-packagecloud (>= 0)
+    expectedbehavior-instrumentald (0.0.4)
+      computology-packagecloud (>= 0.2.10)
 
 DEPENDENCIES
   computology-packagecloud (>= 0)
-  instrumental_tools (>= 0)
+  expectedbehavior-instrumentald (>= 0)
 


### PR DESCRIPTION
Minor tweaks to chef/puppet to make the existing tests and packages work.  Remove Gentoo from chef, as it is very brittle, possibly broken, and probably not the best choice for servers anyway.