### PR TITLE
Tweak System Metrics

### DIFF
--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -803,6 +803,8 @@
   name_override = "system"
   [inputs.net.tags]
     system_measurement_tag = "network"
+  [inputs.net.tagdrop]
+    interface = ["all"]
 
 
 # # TCP or UDP 'ping' given url and collect response time in seconds

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -129,21 +129,21 @@
     system_measurement_tag = "disk"
 
 
-# Read metrics about disk IO by device
-[[inputs.diskio]]
-  ## By default, telegraf will gather stats for all devices including
-  ## disk partitions.
-  ## Setting devices will restrict the stats to the specified devices.
-  # devices = ["sda", "sdb"]
-  ## Uncomment the following line if you do not need disk serial numbers.
-  # skip_serial_number = true
+# # Read metrics about disk IO by device
+# [[inputs.diskio]]
+#   ## By default, telegraf will gather stats for all devices including
+#   ## disk partitions.
+#   ## Setting devices will restrict the stats to the specified devices.
+#   # devices = ["sda", "sdb"]
+#   ## Uncomment the following line if you do not need disk serial numbers.
+#   # skip_serial_number = true
 
-  ## These lines fix the system metric names to basically be
-  ## system.<host>.<measurement>.<field>
-  ## Look at the output template for more info.
-  name_override = "system"
-  [inputs.diskio.tags]
-    system_measurement_tag = "diskio"
+#   ## These lines fix the system metric names to basically be
+#   ## system.<host>.<measurement>.<field>
+#   ## Look at the output template for more info.
+#   name_override = "system"
+#   [inputs.diskio.tags]
+#     system_measurement_tag = "diskio"
 
 
 # Get kernel statistics from /proc/stat

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -192,6 +192,7 @@
   ## system.<host>.<measurement>.<field>
   ## Look at the output template for more info.
   name_override = "system"
+  fieldpass = ["used", "free"]
   [inputs.swap.tags]
     system_measurement_tag = "swap"
 

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -125,6 +125,8 @@
   ## system.<host>.<measurement>.<field>
   ## Look at the output template for more info.
   name_override = "system"
+  tagexclude = ["fstype"]
+  fieldpass = ["free", "total", "used", "used_percent"]
   [inputs.disk.tags]
     system_measurement_tag = "disk"
 

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -147,15 +147,15 @@
 
 
 # Get kernel statistics from /proc/stat
-[[inputs.kernel]]
-  # no configuration
-
-  ## These lines fix the system metric names to basically be
-  ## system.<host>.<measurement>.<field>
-  ## Look at the output template for more info.
-  name_override = "system"
-  [inputs.kernel.tags]
-    system_measurement_tag = "kernel"
+# [[inputs.kernel]]
+#   # no configuration
+#
+#   ## These lines fix the system metric names to basically be
+#   ## system.<host>.<measurement>.<field>
+#   ## Look at the output template for more info.
+#   name_override = "system"
+#   [inputs.kernel.tags]
+#     system_measurement_tag = "kernel"
 
 
 # Read metrics about memory usage


### PR DESCRIPTION
This PR reduces the total count of metrics collected by `instrumentald`in order to make it:

- less costly
- easier to understand

The changes:

- remove all diskio metrics
- remove all kernel metrics
- remove all `inodes_*` disk metrics
- only collect `used` and `free` memory
- remove network metrics for the `all` adapter

It also removes the filesystem type from the metric name for all disk metrics.