### PR TITLE
More System Metrics Tweaks

### DIFF
--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -205,6 +205,7 @@
   ## system.<host>.<measurement>.<field>
   ## Look at the output template for more info.
   name_override = "system"
+  fieldpass=["load*"]
   [inputs.system.tags]
     system_measurement_tag = "system"
 

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -172,16 +172,16 @@
     system_measurement_tag = "memory"
 
 
-# Get the number of processes and group them by status
-[[inputs.processes]]
-  # no configuration
-
-  ## These lines fix the system metric names to basically be
-  ## system.<host>.<measurement>.<field>
-  ## Look at the output template for more info.
-  name_override = "system"
-  [inputs.processes.tags]
-    system_measurement_tag = "processes"
+# # Get the number of processes and group them by status
+# [[inputs.processes]]
+#   # no configuration
+#
+#   ## These lines fix the system metric names to basically be
+#   ## system.<host>.<measurement>.<field>
+#   ## Look at the output template for more info.
+#   name_override = "system"
+#   [inputs.processes.tags]
+#     system_measurement_tag = "processes"
 
 
 # Read metrics about swap memory usage

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -207,7 +207,7 @@
   name_override = "system"
   fieldpass=["load*"]
   [inputs.system.tags]
-    system_measurement_tag = "system"
+    system_measurement_tag = "load"
 
 
 # # Read stats from an aerospike server

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -108,6 +108,7 @@
   ## system.<host>.<measurement>.<field>
   ## Look at the output template for more info.
   name_override = "system"
+  tagexclude = ["cpu"]
   [inputs.cpu.tags]
     system_measurement_tag = "cpu"
 


### PR DESCRIPTION
A few more changes related to #39:

- remove all processes metrics
- only collect `load*` metrics from the system input
- change the `system` measurement namespace to be called `load` 
- reduce the CPU metric namespace by removing the unnecessary `cpu-total`