### PR TITLE
Make System Metrics Optional

### DIFF
--- a/chef/instrumentald/templates/default/instrumentald.toml.erb
+++ b/chef/instrumentald/templates/default/instrumentald.toml.erb
@@ -3,6 +3,8 @@
 # following line to have instrumentald start sending metrics for your project.
 
 # project_token = "<%= @project_token %>"
+
+system = ["cpu", "disk", "load", "memory", "network"]
 # redis = ["tcp://localhost:6379"]
 # memcached = ["localhost:11211"]
 # mongodb = ["localhost:27017"]

--- a/chef/instrumentald/templates/default/instrumentald.toml.erb
+++ b/chef/instrumentald/templates/default/instrumentald.toml.erb
@@ -4,7 +4,7 @@
 
 # project_token = "<%= @project_token %>"
 
-system = ["cpu", "disk", "load", "memory", "network"]
+system = ["cpu", "disk", "load", "memory", "network", "swap"]
 # redis = ["tcp://localhost:6379"]
 # memcached = ["localhost:11211"]
 # mongodb = ["localhost:27017"]

--- a/conf/instrumentald.toml
+++ b/conf/instrumentald.toml
@@ -3,6 +3,7 @@
 # start sending metrics for your project.
 
 project_token = "YOUR_PROJECT_TOKEN"
+# system = true
 # docker = ["unix:///var/run/docker.sock"]
 # memcached = ["localhost:11211"]
 # mongodb = ["localhost:27017"]

--- a/conf/instrumentald.toml
+++ b/conf/instrumentald.toml
@@ -4,7 +4,7 @@
 
 project_token = "YOUR_PROJECT_TOKEN"
 
-system = ["cpu", "disk", "load", "memory", "network"]
+system = ["cpu", "disk", "load", "memory", "network", "swap"]
 # docker = ["unix:///var/run/docker.sock"]
 # memcached = ["localhost:11211"]
 # mongodb = ["localhost:27017"]

--- a/conf/instrumentald.toml
+++ b/conf/instrumentald.toml
@@ -3,7 +3,8 @@
 # start sending metrics for your project.
 
 project_token = "YOUR_PROJECT_TOKEN"
-# system = true
+
+system = ["cpu", "disk", "load", "memory", "network"]
 # docker = ["unix:///var/run/docker.sock"]
 # memcached = ["localhost:11211"]
 # mongodb = ["localhost:27017"]

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -143,16 +143,18 @@ class ServerController < Pidly::Control
   end
 
   def system_metrics_config
+    return @system_metrics_config_value if @system_metrics_config_value
     config_value  = config_file["system"]
     default_value = ["cpu", "disk", "load", "memory", "network"]
 
-    if config_value == true
-      default_value
-    elsif config_value.is_a?(Array)
-      config_value & default_value # intersection of default and config
-    else
-      []
-    end
+    @system_metrics_config_value =
+      if config_value == true
+        default_value
+      elsif config_value.is_a?(Array)
+        config_value & default_value # intersection of default and config
+      else
+        []
+      end
   end
 
   def enable_scripts?

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -60,7 +60,8 @@ class ServerController < Pidly::Control
     config_contents = if File.exist?(opts[:config_file])
       TOML::Parser.new(File.read(opts[:config_file])).parsed
     else
-      puts "Config file #{opts[:config_file]} not found, defaulting to an empty config"
+      puts "Config file #{opts[:config_file]} not found, using default config"
+      { 'system' => true }
     end
     if config_contents.is_a?(Hash)
       @config_file = config_contents

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -192,6 +192,7 @@ class ServerController < Pidly::Control
     nginx_servers      = Array(config_file['nginx'])
     postgresql_servers = Array(config_file["postgresql"])
     redis_servers      = Array(config_file["redis"])
+    system_metrics     = config_file["system"] || true
 
     File.open(telegraf_config_path, "w+") do |config|
       result = ERB.new(File.read(telegraf_template_config_path)).result(binding)

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -140,12 +140,16 @@ class ServerController < Pidly::Control
     !!opts[:debug]
   end
 
-  def collect_system_metrics?
-    config_value = config_file["system"]
-    if config_value
-      !!config_value
+  def system_metrics_config
+    config_value  = config_file["system"]
+    default_value = ["cpu", "disk", "load", "memory", "network"]
+
+    if config_value == true
+      default_value
+    elsif config_value.is_a?(Array)
+      config_value & default_value # intersection of default and config
     else
-      true
+      []
     end
   end
 

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -145,7 +145,7 @@ class ServerController < Pidly::Control
   def system_metrics_config
     return @system_metrics_config_value if @system_metrics_config_value
     config_value  = config_file["system"]
-    default_value = ["cpu", "disk", "load", "memory", "network"]
+    default_value = ["cpu", "disk", "load", "memory", "network", "swap"]
 
     @system_metrics_config_value =
       if config_value == true

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -8,6 +8,7 @@ class ServerController < Pidly::Control
   COMMANDS = [:start, :stop, :status, :restart, :clean, :kill, :foreground]
   TELEGRAF_FAILURE_LOGGING_THROTTLE = 100
   TELEGRAF_FAILURE_SLEEP = 1
+  DEFAULT_CONFIG_CONTENTS = { 'system' => true }
 
   attr_accessor :run_options, :default_options, :pid
   attr_reader :current_project_token
@@ -61,7 +62,7 @@ class ServerController < Pidly::Control
       TOML::Parser.new(File.read(opts[:config_file])).parsed
     else
       puts "Config file #{opts[:config_file]} not found, using default config"
-      { 'system' => true }
+      DEFAULT_CONFIG_CONTENTS
     end
     if config_contents.is_a?(Hash)
       @config_file = config_contents

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -212,9 +212,19 @@ class ServerController < Pidly::Control
     end
   end
 
+  def configured_to_collect_any_metrics?
+    service_keys = ["docker", "memcached", "mongodb", "mysql", "nginx", "postgresql", "redis"]
+    system_metrics_config.any? || (config_file.keys & service_keys).any?
+  end
+
   def run
     puts "instrumentald version #{Instrumentald::VERSION} started at #{Time.now.utc}"
     puts "Collecting stats under the hostname: #{hostname}"
+
+    unless configured_to_collect_any_metrics?
+      puts "No system or service metrics configured. Stopping."
+      return false
+    end
 
     process_telegraf_config
     run_telegraf

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -140,6 +140,15 @@ class ServerController < Pidly::Control
     !!opts[:debug]
   end
 
+  def collect_system_metrics?
+    config_value = config_file["system"]
+    if config_value
+      !!config_value
+    else
+      true
+    end
+  end
+
   def enable_scripts?
     !!opts[:enable_scripts]
   end
@@ -192,7 +201,6 @@ class ServerController < Pidly::Control
     nginx_servers      = Array(config_file['nginx'])
     postgresql_servers = Array(config_file["postgresql"])
     redis_servers      = Array(config_file["redis"])
-    system_metrics     = config_file["system"] || true
 
     File.open(telegraf_config_path, "w+") do |config|
       result = ERB.new(File.read(telegraf_template_config_path)).result(binding)

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -96,7 +96,7 @@
 ###############################################################################
 
 # Read metrics about cpu usage
-<% if opts[:system] %>
+<% if collect_system_metrics? %>
 [[inputs.cpu]]
   ## Whether to report per-cpu stats or not
   percpu = false
@@ -115,7 +115,7 @@
 <% end %>
 
 # Read metrics about disk usage by mount point
-<% if opts[:system] %>
+<% if collect_system_metrics? %>
 [[inputs.disk]]
   ## By default, telegraf gather stats for all mountpoints.
   ## Setting mountpoints will restrict the stats to the specified mountpoints.
@@ -164,7 +164,7 @@
 #     system_measurement_tag = "kernel"
 
 # Read metrics about memory usage
-<% if opts[:system] %>
+<% if collect_system_metrics? %>
 [[inputs.mem]]
   # no configuration
 
@@ -189,7 +189,7 @@
 
 
 # Read metrics about swap memory usage
-<% if opts[:system] %>
+<% if collect_system_metrics? %>
 [[inputs.swap]]
   # no configuration
 
@@ -203,7 +203,7 @@
 <% end %>
 
 # Read metrics about system load & uptime
-<% if opts[:system] %>
+<% if collect_system_metrics? %>
 [[inputs.system]]
   # no configuration
 
@@ -797,7 +797,7 @@
 
 
 # Read metrics about network interface usage
-<% if opts[:system] %>
+<% if collect_system_metrics? %>
 [[inputs.net]]
   ## By default, telegraf gathers stats from any up interface (excluding loopback)
   ## Setting interfaces will tell it to gather these explicit interfaces,

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -96,7 +96,7 @@
 ###############################################################################
 
 # Read metrics about cpu usage
-<% if collect_system_metrics? %>
+<% if system_metrics_config.include?("cpu") %>
 [[inputs.cpu]]
   ## Whether to report per-cpu stats or not
   percpu = false
@@ -115,7 +115,7 @@
 <% end %>
 
 # Read metrics about disk usage by mount point
-<% if collect_system_metrics? %>
+<% if system_metrics_config.include?("disk") %>
 [[inputs.disk]]
   ## By default, telegraf gather stats for all mountpoints.
   ## Setting mountpoints will restrict the stats to the specified mountpoints.
@@ -164,7 +164,7 @@
 #     system_measurement_tag = "kernel"
 
 # Read metrics about memory usage
-<% if collect_system_metrics? %>
+<% if system_metrics_config.include?("memory") %>
 [[inputs.mem]]
   # no configuration
 
@@ -189,7 +189,7 @@
 
 
 # Read metrics about swap memory usage
-<% if collect_system_metrics? %>
+<% if system_metrics_config.include?("swap") %>
 [[inputs.swap]]
   # no configuration
 
@@ -203,7 +203,7 @@
 <% end %>
 
 # Read metrics about system load & uptime
-<% if collect_system_metrics? %>
+<% if system_metrics_config.include?("load") %>
 [[inputs.system]]
   # no configuration
 
@@ -797,7 +797,7 @@
 
 
 # Read metrics about network interface usage
-<% if collect_system_metrics? %>
+<% if system_metrics_config.include?("network") %>
 [[inputs.net]]
   ## By default, telegraf gathers stats from any up interface (excluding loopback)
   ## Setting interfaces will tell it to gather these explicit interfaces,

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -96,6 +96,7 @@
 ###############################################################################
 
 # Read metrics about cpu usage
+<% if opts[:system] %>
 [[inputs.cpu]]
   ## Whether to report per-cpu stats or not
   percpu = false
@@ -111,8 +112,10 @@
   tagexclude = ["cpu"]
   [inputs.cpu.tags]
     system_measurement_tag = "cpu"
+<% end %>
 
 # Read metrics about disk usage by mount point
+<% if opts[:system] %>
 [[inputs.disk]]
   ## By default, telegraf gather stats for all mountpoints.
   ## Setting mountpoints will restrict the stats to the specified mountpoints.
@@ -130,7 +133,7 @@
   fieldpass = ["free", "total", "used", "used_percent"]
   [inputs.disk.tags]
     system_measurement_tag = "disk"
-
+<% end %>
 
 # # Read metrics about disk IO by device
 # [[inputs.diskio]]
@@ -160,8 +163,8 @@
 #   [inputs.kernel.tags]
 #     system_measurement_tag = "kernel"
 
-
 # Read metrics about memory usage
+<% if opts[:system] %>
 [[inputs.mem]]
   # no configuration
 
@@ -171,7 +174,7 @@
   name_override = "system"
   [inputs.mem.tags]
     system_measurement_tag = "memory"
-
+<% end %>
 
 # # Get the number of processes and group them by status
 # [[inputs.processes]]
@@ -186,6 +189,7 @@
 
 
 # Read metrics about swap memory usage
+<% if opts[:system] %>
 [[inputs.swap]]
   # no configuration
 
@@ -196,9 +200,10 @@
   fieldpass = ["used", "free"]
   [inputs.swap.tags]
     system_measurement_tag = "swap"
-
+<% end %>
 
 # Read metrics about system load & uptime
+<% if opts[:system] %>
 [[inputs.system]]
   # no configuration
 
@@ -209,7 +214,7 @@
   fieldpass=["load*"]
   [inputs.system.tags]
     system_measurement_tag = "load"
-
+<% end %>
 
 # # Read stats from an aerospike server
 # [[inputs.aerospike]]
@@ -792,6 +797,7 @@
 
 
 # Read metrics about network interface usage
+<% if opts[:system] %>
 [[inputs.net]]
   ## By default, telegraf gathers stats from any up interface (excluding loopback)
   ## Setting interfaces will tell it to gather these explicit interfaces,
@@ -807,7 +813,7 @@
     system_measurement_tag = "network"
   [inputs.net.tagdrop]
     interface = ["all"]
-
+<% end %>
 
 # # TCP or UDP 'ping' given url and collect response time in seconds
 # [[inputs.net_response]]

--- a/puppet/instrumentald/templates/instrumentald.toml.erb
+++ b/puppet/instrumentald/templates/instrumentald.toml.erb
@@ -3,6 +3,8 @@
 # instrumentald start sending metrics for your project.
 
 # project_token = "YOUR_PROJECT_TOKEN"
+
+system = ["cpu", "disk", "load", "memory", "network"]
 # redis = ["tcp://localhost:6379"]
 # memcached = ["localhost:11211"]
 # mongodb = ["localhost:27017"]

--- a/puppet/instrumentald/templates/instrumentald.toml.erb
+++ b/puppet/instrumentald/templates/instrumentald.toml.erb
@@ -4,7 +4,7 @@
 
 # project_token = "YOUR_PROJECT_TOKEN"
 
-system = ["cpu", "disk", "load", "memory", "network"]
+system = ["cpu", "disk", "load", "memory", "network", "swap"]
 # redis = ["tcp://localhost:6379"]
 # memcached = ["localhost:11211"]
 # mongodb = ["localhost:27017"]


### PR DESCRIPTION
There are some cases where someone will not want to collect system metrics on a machine. We should allow that, while still making `instrumentald` collect system metrics by default.