### PR TITLE
Remove unused WRAPPER_SCRIPT_BAT

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -52,17 +52,6 @@ unset BUNDLE_IGNORE_CONFIG
 exec "$SELFDIR/lib/ruby/bin/ruby" -rbundler/setup "$SELFDIR/lib/app/%s" "$@"
 EOSCRIPT
 
-WRAPPER_SCRIPT_BAT = <<-EOSCRIPT
-@echo off
-
-:: Tell Bundler where the Gemfile and gems are.
-set "BUNDLE_GEMFILE=%%~dp0\\lib\\vendor\\Gemfile"
-set BUNDLE_IGNORE_CONFIG=
-
-:: Run the actual app using the bundled Ruby interpreter, with Bundler activated.
-@"%%~dp0\\lib\\ruby\\bin\\ruby.bat" -rbundler/setup "%%~dp0\\lib\\app\\%s" %%*
-EOSCRIPT
-
 ARCHITECTURES          = {
                            'linux-x86' => {
                              runtime:      TRAVELING_RUBY_FILE % "linux-x86",


### PR DESCRIPTION
WRAPPER_SCRIPT_BAT was only used when building for win32, which was removed in #37