### PR TITLE
Add a homebrew formula to make installing instrumentald on macOS easier

### DIFF
--- a/HomebrewFormula/instrumentald.rb
+++ b/HomebrewFormula/instrumentald.rb
@@ -20,6 +20,10 @@ class Instrumentald < Formula
 
   def post_install
     FileUtils.chmod 0666, "#{bin}/lib/vendor/Gemfile.lock"
-    ohai "instrumentald is ready to go! More info about getting started at https://instrumentalapp.com/docs/isd/getting-started"
+
+    ohai "instrumentald is \e[32mready to go!\e[0m"
+    ohai "  instrumentald -k <PROJECT_TOKEN>"
+
+    opoo "You need an Instrumental account and a project key to run instrumentald. More info: \e[4m\e[33mhttps://instrumentalapp.com/docs/isd/getting-started\e[0m"
   end
 end

--- a/HomebrewFormula/instrumentald.rb
+++ b/HomebrewFormula/instrumentald.rb
@@ -1,0 +1,21 @@
+class Instrumentald < Formula
+  head "https://github.com/Instrumental/instrumentald.git"
+  desc "A server agent that provides system monitoring and service monitoring. It's fast, reliable, runs on anything *nix, is simple to configure and deploy, and has a small memory footprint."
+  homepage "https://github.com/Instrumental/instrumentald"
+  url "https://github.com/Instrumental/instrumentald/releases/download/0.0.5/instrumentald_0.0.5_osx.tar.gz"
+  version "0.0.5"
+  sha256 "1c6eb9516c9a99d8ba55d1ab3a99d744c442f1aafbe2ded220302b76288c6023"
+
+  def install
+    inreplace "opt/instrumentald/instrumentald" do |s|
+      s.gsub! /SELFDIR=.*/, "SELFDIR=\"#{bin}\""
+    end
+
+    bin.install Dir["opt/instrumentald/*"]
+  end
+
+  def post_install
+    FileUtils.chmod 0666, "#{bin}/lib/vendor/Gemfile.lock"
+    ohai "instrumentald is ready to go! More info about getting started at https://instrumentalapp.com/docs/isd/getting-started"
+  end
+end

--- a/HomebrewFormula/instrumentald.rb
+++ b/HomebrewFormula/instrumentald.rb
@@ -7,6 +7,10 @@ class Instrumentald < Formula
   sha256 "1c6eb9516c9a99d8ba55d1ab3a99d744c442f1aafbe2ded220302b76288c6023"
 
   def install
+    # The binary will think it's in one place (/usr/local/bin/), but the lib
+    # files it wants are actually somewhere else (/usr/local/Cellar/instrumentald/VERSION/bin)
+    # Rather than making a custom version of this executable for homebrew, let's
+    # just edit-in-place to make do right
     inreplace "opt/instrumentald/instrumentald" do |s|
       s.gsub! /SELFDIR=.*/, "SELFDIR=\"#{bin}\""
     end

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,14 +12,12 @@ Prebuilt `deb` and `rpm` packages are available via the [packagecloud.io](https:
 * 32-bit Linux tarball (CoreOS, etc.) [https://s3.amazonaws.com/instrumentald/1.1.2/instrumentald_1.1.2_linux-x86.tar.gz](https://s3.amazonaws.com/instrumentald/1.1.2/instrumentald_1.1.2_linux-x86.tar.gz)
 * 64-bit Mac OS X tarball [https://s3.amazonaws.com/instrumentald/1.1.2/instrumentald_1.1.2_osx.tar.gz](https://s3.amazonaws.com/instrumentald/1.1.2/instrumentald_1.1.2_osx.tar.gz)
 
- # OS X / Mac
- # macOS
+ # OSX/macOS
 
  Use pkg installer, then configure `/etc/instrumentald.toml` and run:
  ## Via Homebrew
 
  ```
- brew update
  brew install instrumental/instrumentald/instrumentald
  ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,9 +12,24 @@ Prebuilt `deb` and `rpm` packages are available via the [packagecloud.io](https:
 * 32-bit Linux tarball (CoreOS, etc.) [https://s3.amazonaws.com/instrumentald/1.1.2/instrumentald_1.1.2_linux-x86.tar.gz](https://s3.amazonaws.com/instrumentald/1.1.2/instrumentald_1.1.2_linux-x86.tar.gz)
 * 64-bit Mac OS X tarball [https://s3.amazonaws.com/instrumentald/1.1.2/instrumentald_1.1.2_osx.tar.gz](https://s3.amazonaws.com/instrumentald/1.1.2/instrumentald_1.1.2_osx.tar.gz)
 
-# OS X / Mac
+ # OS X / Mac
+ # macOS
 
-Use pkg installer, then configure `/etc/instrumentald.toml` and run:
+ Use pkg installer, then configure `/etc/instrumentald.toml` and run:
+ ## Via Homebrew
+
+ ```
+ brew update
+ brew install instrumental/instrumentald/instrumentald
+ ```
+
+ The Homebrew installer does not add `/etc/instrumentald.toml` or set `instrumentald` to run at startup. It's intended to make it easier to kick the tires, not for production metric gathering.
+
+ ## pkg
+
+ Use pkg installer, then configure `/etc/instrumentald.toml`.
+
+ To make `instrumentald` run at startup, run:
 
 ```sh
 launchctl load /opt/instrumentald/lib/app/osx/instrumentald.plist


### PR DESCRIPTION
This formula uses the OSX tarball generated by fpm and assumes it's uploaded to GitHub as a release. 

Our users will run the following to install `instrumentald` via homebrew:

```
brew install instrumental/instrumentald/instrumentald
```

This PR *does not* include changes to our build scripts that update the formula details (version, url, hash). Put another way: **this formula will need to be manually updated when releases happen**. given that it relies on on GitHub releases which is not currently automated, and given that this formula will be used from master whenever invoked by a user, it seemed prudent to not automate it until we automate GitHub releases.

If you'd like to test this locally, you can do what I did:

```
brew update &&  ln -s ~/YOUR_PROJECTS_DIR/instrumentald/HomebrewFormula/instrumentald.rb /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/formula/instrumentald.rb

brew install instrumentald
```
