### PR TITLE
[HOTFIX] Add Gemfile/Gemfile.lock back to packages

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -315,8 +315,8 @@ def create_directory_bundle(target, wrapper_script, separator, extension = nil, 
     sh %Q{chmod +x "%s"} % destination
   end
 
-  sh %Q{cp -pR "%s" "%s"}                  % [vendor_dir, lib_dir]
-
+  sh %Q{cp -pR "%s" "%s"}             % [vendor_dir, lib_dir]
+  sh %Q{cp Gemfile Gemfile.lock "%s"} % dest_vendor_dir
 
   sh %Q{ln -sf "../app/%s" "%s"} % ["lib", File.join(dest_vendor_dir, "lib")]
 


### PR DESCRIPTION
This line was removed in #38, when it should have just been edited to remove `spec_path`. As is, built packages won't actually run.