### PR TITLE
No autostart on install

### DIFF
--- a/debian/after-install.sh
+++ b/debian/after-install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
 update-rc.d instrumentald defaults
-/etc/init.d/instrumentald start
 echo "Remember to edit /etc/instrumentald.toml with your Instrumental Project Token"
+echo "InstrumentalD will be enabled by default at next reboot"
+echo "To (re)start the daemon, use 'sudo /etc/init.d/instrumentald restart'"
 exit 0

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -68,7 +68,7 @@
 
 [[outputs.instrumental]]
   ## Project Token (required)
-  api_token = "<%= instrumental_project_token %>"  # required
+  api_token = "<%= project_token %>"  # required
   ## Prefix the metrics with a given name
   prefix = ""
   ## Stats output template (Graphite formatting)

--- a/rpm/after-install.sh
+++ b/rpm/after-install.sh
@@ -2,6 +2,7 @@
 set -e
 chkconfig --add instrumentald
 chkconfig instrumentald on
-service instrumentald start
 echo "Remember to edit /etc/instrumentald.toml with your Instrumental Project Token"
+echo "InstrumentalD will be enabled by default at next reboot"
+echo "To (re)start the daemon, use 'sudo service instrumentald restart'"
 exit 0


### PR DESCRIPTION
When installing a InstrumentalD as a package you may be surprised when it starts, even though there is zero chance it has a project token configured.

Stop doing that.  If it requires configuration, you should have to start it explicitly.