### PR TITLE
Add support for Debian 8 and Ubuntu 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.1 [March 9, 2017]
+ * Improve installation scripts for compatibility with Ubuntu 16, Debian 8
+ * Add Debian 8 release target
+
 ### 1.0.0 [Oct 6, 2016]
  * 1.0.0beta4 is now 1.0.0
 

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,8 @@ SUPPORTED_DISTROS      = {
     'ubuntu/precise', # 12.04
     'ubuntu/trusty',  # 14.04
     'ubuntu/xenial',  # 16.04
-    'debian/wheezy'   # 7.0
+    'debian/wheezy',  # 7.0
+    'debian/jessie'   # 8.0
   ],
   'rpm' => [
     'el/5',

--- a/chef/.kitchen.yml
+++ b/chef/.kitchen.yml
@@ -11,6 +11,7 @@ provisioner:
   chef_omnibus_url: "https://raw.githubusercontent.com/instrumental/instrumentald/master/chef/omnibus.sh"
 
 platforms:
+  - name: debian-7.11
   - name: ubuntu-12.04
   - name: ubuntu-14.04
   # ubuntu 16 works differently, and this doesn't work currently

--- a/chef/.kitchen.yml
+++ b/chef/.kitchen.yml
@@ -12,13 +12,11 @@ provisioner:
 
 platforms:
   - name: debian-7.11
+  - name: debian-8.7
   - name: ubuntu-12.04
   - name: ubuntu-14.04
-  # ubuntu 16 works differently, and this doesn't work currently
-  # - name: ubuntu-16.04
+  - name: ubuntu-16.04
   - name: centos-6.7
-  # gentoo is probably not a good choice for servers, and would take some more effort to make work
-  # - name: "d11wtq/gentoo"
 
 suites:
   - name: default

--- a/chef/instrumentald/attributes/default.rb
+++ b/chef/instrumentald/attributes/default.rb
@@ -1,7 +1,7 @@
 default[:instrumental]                   = {}
 default[:instrumental][:project_token]   = "YOUR_PROJECT_TOKEN"
 
-default[:instrumental][:version]         = "1.0.0"
+default[:instrumental][:version]         = "1.0.1"
 default[:instrumental][:repo]            = "https://s3.amazonaws.com/instrumentald"
 
 default[:instrumental][:curl_path]       = "/usr/bin/curl"

--- a/debian/after-install.sh
+++ b/debian/after-install.sh
@@ -1,8 +1,20 @@
 #!/bin/sh
 set -e
-update-rc.d instrumentald defaults
 
-echo "Remember to edit /etc/instrumentald.toml with your Instrumental Project Token"
-echo "InstrumentalD will be enabled by default at next reboot"
-echo "To (re)start the daemon, use 'sudo /etc/init.d/instrumentald restart'"
+if dpkg -S /sbin/init | grep -q 'sysvinit'
+then
+  update-rc.d instrumentald defaults
+  echo "InstrumentalD will be enabled by default at next reboot"
+  echo "To (re)start the daemon, use 'sudo /etc/init.d/instrumentald restart'"
+  echo "Remember to edit /etc/instrumentald.toml with your Instrumental Project Token"
+elif dpkg -S /sbin/init | grep -q 'systemd'
+then
+  systemctl enable instrumentald.service
+  systemctl start instrumentald
+  echo "InstrumentalD will be enabled by default at next reboot"
+  echo "To (re)start the daemon, use 'sudo systemctl start instrumentald'"
+  echo "Remember to edit /etc/instrumentald.toml with your Instrumental Project Token"
+else
+  echo "Starting InstrumentalD failed, could not determine whether to use sysvinit or systemd"
+fi
 exit 0

--- a/debian/after-remove.sh
+++ b/debian/after-remove.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
 set -e
-update-rc.d -f instrumentald remove
+if dpkg -S /sbin/init | grep -q 'sysvinit'
+then
+  update-rc.d -f instrumentald remove
+elif dpkg -S /sbin/init | grep -q 'systemd'
+then
+  systemctl disable instrumentald.service
+fi
 exit 0

--- a/debian/before-remove.sh
+++ b/debian/before-remove.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
 set -e
-/etc/init.d/instrumentald stop
+if dpkg -S /sbin/init | grep -q 'sysvinit'
+then
+  /etc/init.d/instrumentald stop
+elif dpkg -S /sbin/init | grep -q 'systemd'
+then
+  systemctl stop instrumentald
+fi
 exit 0

--- a/lib/instrumentald/version.rb
+++ b/lib/instrumentald/version.rb
@@ -1,3 +1,3 @@
 module Instrumentald
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/puppet/instrumentald/metadata.json
+++ b/puppet/instrumentald/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "instrumental-instrumentald",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Expected Behavior",
   "license": "MIT",
   "source": "https://github.com/instrumental/instrumentald",


### PR DESCRIPTION
Debian 8 ad Ubuntu 16 use `systemd` instead of `sysvinit` by default for service management, so our after-install, after-remove, and before-remove scripts do not work as expected there. This updates those scripts to check for which is used, and act appropriately.

Also, fpm was not set up to build for Debian 8.