### PR TITLE
[HOTFIX] Fix Ubuntu 12 regression in Debian packaging scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.0.2 [March 9, 2017]
+ * Fix Ubuntu 12 regression in packaging scripts
+
 ### 1.0.1 [March 9, 2017]
  * Improve installation scripts for compatibility with Ubuntu 16, Debian 8
  * Add Debian 8 release target

--- a/chef/instrumentald/attributes/default.rb
+++ b/chef/instrumentald/attributes/default.rb
@@ -1,7 +1,7 @@
 default[:instrumental]                   = {}
 default[:instrumental][:project_token]   = "YOUR_PROJECT_TOKEN"
 
-default[:instrumental][:version]         = "1.0.1"
+default[:instrumental][:version]         = "1.0.2"
 default[:instrumental][:repo]            = "https://s3.amazonaws.com/instrumentald"
 
 default[:instrumental][:curl_path]       = "/usr/bin/curl"

--- a/debian/after-install.sh
+++ b/debian/after-install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-if dpkg -S /sbin/init | grep -q 'sysvinit'
+if dpkg -S /sbin/init | grep -q 'sysvinit' || dpkg -S /sbin/init | grep -q 'upstart'
 then
   update-rc.d instrumentald defaults
   echo "InstrumentalD will be enabled by default at next reboot"

--- a/debian/after-remove.sh
+++ b/debian/after-remove.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-if dpkg -S /sbin/init | grep -q 'sysvinit'
+if dpkg -S /sbin/init | grep -q 'sysvinit' || dpkg -S /sbin/init | grep -q 'upstart'
 then
   update-rc.d -f instrumentald remove
 elif dpkg -S /sbin/init | grep -q 'systemd'

--- a/debian/before-remove.sh
+++ b/debian/before-remove.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-if dpkg -S /sbin/init | grep -q 'sysvinit'
+if dpkg -S /sbin/init | grep -q 'sysvinit' || dpkg -S /sbin/init | grep -q 'upstart'
 then
   /etc/init.d/instrumentald stop
 elif dpkg -S /sbin/init | grep -q 'systemd'

--- a/lib/instrumentald/version.rb
+++ b/lib/instrumentald/version.rb
@@ -1,3 +1,3 @@
 module Instrumentald
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/puppet/instrumentald/metadata.json
+++ b/puppet/instrumentald/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "instrumental-instrumentald",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Expected Behavior",
   "license": "MIT",
   "source": "https://github.com/instrumental/instrumentald",


### PR DESCRIPTION
In adding support for Debian 8 and Ubuntu 16 in #60, we accidentally broke support for Ubuntu 12. This fixes that by also accepting `upstart` in addition to `sysvinit`.