### PR TITLE
Improve first run project setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ group :development do
   gem "librarian-puppet"
   gem "puppet"
   gem "serverspec"
+  gem "CFPropertyList" # currently prevents "fatal: No live threads left. Deadlock"
 end

--- a/script/setup
+++ b/script/setup
@@ -6,6 +6,9 @@ brew list gnu-tar >/dev/null 2>&1 || brew install gnu-tar
 brew list rpm >/dev/null 2>&1 || brew install rpm
 brew list go >/dev/null 2>&1 || brew install go --with-cc-all
 
+brew cask list vagrant >/dev/null 2>&1 || brew cask install vagrant
+brew cask list virtualbox >/dev/null 2>&1 || brew cask install virtualbox
+
 rbenv which ruby >/dev/null 2>&1 || (brew upgrade ruby-build || true; rbenv install)
 gem list -i bundler >/dev/null || gem install bundler
 bundle install


### PR DESCRIPTION
The tests depend on vagrant and virtualbox, but they weren't specified
in `script/setup` so you couldn't run the tests immediately after setup.

This also fixes an error with the initial `bundle install`:

```
[master] instrumentald $ ./script/setup
Fetching gem metadata from https://rubygems.org/.......
Fetching version metadata from https://rubygems.org/..
Fetching dependency metadata from https://rubygems.org/.
Resolving dependencies........
Your lockfile was created by an old Bundler that left some things out.
You can fix this by adding the missing gems to your Gemfile, running
bundle install, and then removing the gems from your Gemfile.
The missing gems are:
* CFPropertyList depended upon by facter
* CFPropertyList depended upon by puppet
…
fatal: No live threads left. Deadlock?

/Users/jason/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.14.2/lib/bundler/worker.rb:43:in
`pop'

/Users/jason/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/bundler-1.14.2/lib/bundler/worker.rb:43:in
`deq’
…
Unfortunately, an unexpected error occurred, and Bundler cannot
continue.
```

Adding CFPropertyList to the gemfile fixes this. Contrary to the
directions, then removing the gems doesn't work, so it stays for now.