### PR TITLE
Smooth out test running, particularly puppet

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -3,9 +3,9 @@
 You can test installation of `instrumentald` by running the [ServerSpec tests](test/integration/default/serverspec/). From the `chef` or `puppet` directories, run the following command:
 
 ```
-bundle exec kitchen verify
+./script/test
 ```
 
-to test installation and setup procedures for the `instrumentald` command. You must have [Vagrant](https://www.vagrantup.com/) installed; currently the KitchenCI integration is setup to use [VMWare Fusion](http://www.vmware.com/products/fusion) and the [VMWare Fusion Vagrant provider](https://www.vagrantup.com/vmware); you can configure a separate provider for your specific setup by change the `provider` flag in the `.kitchen.yml` file for your particular setup.
+to test installation and setup procedures for the `instrumentald` command. You must have [Vagrant](https://www.vagrantup.com/) installed; currently the KitchenCI integration is setup to use VirtualBox; you can configure a separate provider for your specific setup by change the `provider` flag in the `.kitchen.yml` file for your particular setup.
 
 NOTE: Avoid using Vagrant 1.8.5. It has [a bug](https://github.com/mitchellh/vagrant/issues/7610) which will prevent the tests from running correctly.

--- a/puppet/.kitchen.yml
+++ b/puppet/.kitchen.yml
@@ -1,12 +1,21 @@
 ---
 driver:
   name: vagrant
+  synced_folders:
+    - ["../", "/tools-root"]
 
 provisioner:
   name: puppet_apply
   manifests_path: manifests
   modules_path: modules
-  hiera_data_path: hieradata
+  # puppet_debug: true
+  # puppet_verbose: true
+  # puppet_logdest:
+  #   - console
+  #   - /puppet.log
+  custom_facts:
+    instrumentald_version: <%= `ruby -r#{__FILE__}/../../lib/instrumentald/version -e 'puts Instrumentald::VERSION'`.strip %>
+    instrumentald_use_local: true
 
 platforms:
   - name: nocm_ubuntu-12.04

--- a/puppet/instrumentald/manifests/init.pp
+++ b/puppet/instrumentald/manifests/init.pp
@@ -5,17 +5,32 @@ class instrumentald(
   include packagecloud
 
   case $operatingsystem {
-    'RedHat', 'CentOS': { $package_type = 'rpm' }
-    'Debian', 'Ubuntu': { $package_type = 'deb' }
+    'RedHat', 'CentOS': {
+      $package_type = 'rpm'
+      $provider = 'rpm'
+    }
+    'Debian', 'Ubuntu': {
+      $package_type = 'deb'
+      $provider = 'dpkg'
+    }
   }
 
   packagecloud::repo { "expectedbehavior/instrumental":
     type => $package_type,
   }
 
-  package { "instrumentald":
-    ensure  => latest,
-    require => Packagecloud::Repo["expectedbehavior/instrumental"]
+  if str2bool("$instrumentald_use_local") {
+    package { "instrumentald":
+      ensure  => latest,
+      provider => $provider,
+      source => "/tools-root/instrumentald_${instrumentald_version}_amd64.${package_type}",
+      require => Packagecloud::Repo["expectedbehavior/instrumental"]
+    }
+  } else {
+    package { "instrumentald":
+      ensure  => latest,
+      require => Packagecloud::Repo["expectedbehavior/instrumental"]
+    }
   }
 
   file { "instrumental-config":

--- a/script/test
+++ b/script/test
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Need to build packages for everything because the tests use these packages.
+bundle exec rake package &&
+
+(
+  cd chef &&
+  bundle exec kitchen test
+) &&
+
+(
+  cd puppet &&
+  bundle exec kitchen test
+) &&
+
+success="true"
+
+echo
+
+if [ "$success" == "true" ]; then
+  echo "Tests finished successfully"
+else
+  echo "Tests failed"
+fi
+
+echo


### PR DESCRIPTION
The TEST.md directions were out of date, referencing VMWare instead of
VirtualBox. Also the puppet tests didn't work all the time,
particularly if you were testing a gem that hadn't been released to
packagecloud yet. They gave an error about hiera not working.

This updates the TEST.md directions and adds a `script/test` executable
that automatically runs everything necessary, including packaging and
running both chef and puppet tests.

This also removes hiera usage from puppet and replaces it with vagrant
directory syncing (which is what we already used for chef).

This adds the ability to test unpublished packages with puppet, and
makes that the default (like chef).