### PR TITLE
Allow MongoDB Atlas URIs, including ssl options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.0.3 [April 17, 2017]
+ * Add support for new MongoDB URIs (including Atlas)
+
 ### 1.0.2 [March 9, 2017]
  * Fix Ubuntu 12 regression in packaging scripts
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org/"
 gem "instrumental_agent", ">=0.13.2"
 gem "pidly", ">=0.1.3"
 gem "toml", "~>0.0.3"
+gem "mongo", "~>2.4"
 
 group :development do
   gem "rake", ">=0"

--- a/chef/instrumentald/attributes/default.rb
+++ b/chef/instrumentald/attributes/default.rb
@@ -1,7 +1,7 @@
 default[:instrumental]                   = {}
 default[:instrumental][:project_token]   = "YOUR_PROJECT_TOKEN"
 
-default[:instrumental][:version]         = "1.0.2"
+default[:instrumental][:version]         = "1.0.3"
 default[:instrumental][:repo]            = "https://s3.amazonaws.com/instrumentald"
 
 default[:instrumental][:curl_path]       = "/usr/bin/curl"

--- a/chef/instrumentald/templates/default/instrumentald.toml.erb
+++ b/chef/instrumentald/templates/default/instrumentald.toml.erb
@@ -11,3 +11,13 @@ system = ["cpu", "disk", "load", "memory", "network", "swap"]
 # mysql = ["root@tcp(127.0.0.1:3306)/"]
 # nginx = ["http://localhost:80/status"]
 # postgresql = ["postgres://postgres@localhost?sslmode=disable"]
+
+
+debug = true
+
+# Setup some hosts to test with serverspec
+mongodb = [
+  "mongodb://localhost:27017",
+  "mongodb://instrumentald-atlas-test:<PASSWORD>@cluster0-shard-00-00-uvipm.mongodb.net:27017,cluster0-shard-00-01-uvipm.mongodb.net:27017,cluster0-shard-00-02-uvipm.mongodb.net:27017/<DATABASE>?ssl=true&replicaSet=Cluster0-shard-0&authSource=admin",
+  "test-no-scheme.com:27017"
+]

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -204,10 +204,11 @@ class ServerController < Pidly::Control
     mongodb_configs = mongodb_servers.map do |uri|
       begin
         u = Mongo::URI.new(uri)
-        u.servers.map do |server|
+        servers = u.servers.map do |server|
           creds = "#{u.credentials[:user]}:#{u.credentials[:password]}@" if u.credentials.values.any?
-          {:servers => ["mongodb://#{creds}#{server}"], :ssl => u.uri_options[:ssl]}
+          "mongodb://#{creds}#{server}"
         end
+        {:servers => servers, :ssl => u.uri_options[:ssl]}
       rescue Mongo::Error::InvalidURI => ex
         {:servers => [uri]}
       end

--- a/lib/instrumentald/server_controller.rb
+++ b/lib/instrumentald/server_controller.rb
@@ -4,11 +4,31 @@ require 'toml'
 require 'erb'
 require 'tempfile'
 
+# We're just using this for mongo URI parsing so require the minimum necessary.
+# Unfortunately requiring 'mongo' doesn't work because it tries to load bson
+# native extensions, and they aren't built on the target system.
+# Also, Mongo::URI doesn't autoload Mongo::Loggable or Mongo::Error, so we need
+# to require those as well.
+require 'mongo/loggable'
+require 'mongo/error'
+require 'mongo/uri'
+
+# Mongo has a habit of using BSON::Document whenever they need a hash. Since
+# BSON requires native extensions we stub out their options object.
+module Mongo::Options
+  class Redacted < ::Hash
+    def initialize(hash)
+      self.merge!(hash)
+    end
+  end
+end
+
 class ServerController < Pidly::Control
   COMMANDS = [:start, :stop, :status, :restart, :clean, :kill, :foreground]
   TELEGRAF_FAILURE_LOGGING_THROTTLE = 100
   TELEGRAF_FAILURE_SLEEP = 1
   DEFAULT_CONFIG_CONTENTS = { 'system' => true }
+  TELEGRAF_CONFIG_PATH = File.join(Dir.tmpdir, "instrumentald_telegraf.toml")
 
   attr_accessor :run_options, :default_options, :pid
   attr_reader :agent
@@ -33,7 +53,6 @@ class ServerController < Pidly::Control
   def initialize(options={})
     @run_options = options.delete(:run_options) || {}
     @default_options = options.delete(:default_options) || {}
-    @telegraf_config_tempfile = Tempfile.new("instrumentald_telegraf")
 
     secure_protocol = collector_address.split(':').last != '8000'
     @agent = Instrumental::Agent.new(project_token, :collector => collector_address,
@@ -163,7 +182,7 @@ class ServerController < Pidly::Control
   end
 
   def telegraf_config_path
-    @telegraf_config_tempfile.path
+    TELEGRAF_CONFIG_PATH
   end
 
   def telegraf_template_config_path
@@ -179,10 +198,25 @@ class ServerController < Pidly::Control
     end
   end
 
+  def mongodb_configs
+    mongodb_servers = Array(config_file["mongodb"])
+
+    mongodb_configs = mongodb_servers.map do |uri|
+      begin
+        u = Mongo::URI.new(uri)
+        u.servers.map do |server|
+          creds = "#{u.credentials[:user]}:#{u.credentials[:password]}@" if u.credentials.values.any?
+          {:servers => ["mongodb://#{creds}#{server}"], :ssl => u.uri_options[:ssl]}
+        end
+      rescue Mongo::Error::InvalidURI => ex
+        {:servers => [uri]}
+      end
+    end.flatten.compact
+  end
+
   def process_telegraf_config
     docker_containers  = Array(config_file["docker"])
     memcached_servers  = Array(config_file["memcached"])
-    mongodb_servers    = Array(config_file["mongodb"])
     mysql_servers      = Array(config_file["mysql"])
     nginx_servers      = Array(config_file['nginx'])
     postgresql_servers = Array(config_file["postgresql"])

--- a/lib/instrumentald/version.rb
+++ b/lib/instrumentald/version.rb
@@ -1,3 +1,3 @@
 module Instrumentald
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -720,15 +720,19 @@
 
 
 # # Read metrics from one or many MongoDB servers
-<% if mongodb_servers.any? %>
+<% mongodb_configs.each do |mongodb_config| %>
 [[inputs.mongodb]]
 #   ## An array of URI to gather stats about. Specify an ip or hostname
 #   ## with optional port add password. ie,
 #   ##   mongodb://user:auth_key@10.10.3.30:27017,
 #   ##   mongodb://10.10.3.33:18832,
 #   ##   10.0.0.1:10000, etc.
-  servers = <%= mongodb_servers %>
+  servers = <%= mongodb_config[:servers] %>
   tagexclude = ["state", "host"]
+<% if mongodb_config[:ssl] %>
+  [inputs.mongodb.ssl]
+  enabled = true
+<% end %>
 <% end %>
 
 <% mysql_servers.each do |server_url| %>

--- a/puppet/instrumentald/metadata.json
+++ b/puppet/instrumentald/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "instrumental-instrumentald",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Expected Behavior",
   "license": "MIT",
   "source": "https://github.com/instrumental/instrumentald",

--- a/puppet/instrumentald/templates/instrumentald.toml.erb
+++ b/puppet/instrumentald/templates/instrumentald.toml.erb
@@ -11,3 +11,13 @@ system = ["cpu", "disk", "load", "memory", "network", "swap"]
 # mysql = ["root@tcp(127.0.0.1:3306)/"]
 # nginx = ["http://localhost:80/status"]
 # postgresql = ["postgres://postgres@localhost?sslmode=disable"]
+
+
+debug = true
+
+# Setup some hosts to test with serverspec
+mongodb = [
+  "mongodb://localhost:27017",
+  "mongodb://instrumentald-atlas-test:<PASSWORD>@cluster0-shard-00-00-uvipm.mongodb.net:27017,cluster0-shard-00-01-uvipm.mongodb.net:27017,cluster0-shard-00-02-uvipm.mongodb.net:27017/<DATABASE>?ssl=true&replicaSet=Cluster0-shard-0&authSource=admin",
+  "test-no-scheme.com:27017"
+]

--- a/test/integration/default/serverspec/instrumentald_spec.rb
+++ b/test/integration/default/serverspec/instrumentald_spec.rb
@@ -64,68 +64,54 @@ cat_telegraf_conf = %Q{cat `(ls -tr /tmp/instrumentald_telegraf* || echo "no_tmp
 describe command("#{wait_for_telegraf_conf}; #{cat_telegraf_conf}") do
 
   # Plain, one host, mongodb scheme
-  %w(
-    localhost
-  ).map do |str|
-    its(:stdout) do
-        should include(<<~CONF)
-        [[inputs.mongodb]]
-        #   ## An array of URI to gather stats about. Specify an ip or hostname
-        #   ## with optional port add password. ie,
-        #   ##   mongodb://user:auth_key@10.10.3.30:27017,
-        #   ##   mongodb://10.10.3.33:18832,
-        #   ##   10.0.0.1:10000, etc.
-          servers = ["mongodb://#{str}:27017"]
-          tagexclude = ["state", "host"]
+  its(:stdout) do
+      should include(<<~CONF)
+      [[inputs.mongodb]]
+      #   ## An array of URI to gather stats about. Specify an ip or hostname
+      #   ## with optional port add password. ie,
+      #   ##   mongodb://user:auth_key@10.10.3.30:27017,
+      #   ##   mongodb://10.10.3.33:18832,
+      #   ##   10.0.0.1:10000, etc.
+        servers = ["mongodb://localhost:27017"]
+        tagexclude = ["state", "host"]
 
 
-      CONF
-    end
+    CONF
   end
 
   # Multi-host, mongodb scheme
-  [
-    "instrumentald-atlas-test:<PASSWORD>@cluster0-shard-00-00-uvipm.mongodb.net",
-    "instrumentald-atlas-test:<PASSWORD>@cluster0-shard-00-01-uvipm.mongodb.net",
-    "instrumentald-atlas-test:<PASSWORD>@cluster0-shard-00-02-uvipm.mongodb.net",
-  ].map do |str|
-    its(:stdout) do
-        should include(<<~CONF)
-        [[inputs.mongodb]]
-        #   ## An array of URI to gather stats about. Specify an ip or hostname
-        #   ## with optional port add password. ie,
-        #   ##   mongodb://user:auth_key@10.10.3.30:27017,
-        #   ##   mongodb://10.10.3.33:18832,
-        #   ##   10.0.0.1:10000, etc.
-          servers = ["mongodb://#{str}:27017"]
-          tagexclude = ["state", "host"]
+  its(:stdout) do
+      should include(<<~CONF)
+      [[inputs.mongodb]]
+      #   ## An array of URI to gather stats about. Specify an ip or hostname
+      #   ## with optional port add password. ie,
+      #   ##   mongodb://user:auth_key@10.10.3.30:27017,
+      #   ##   mongodb://10.10.3.33:18832,
+      #   ##   10.0.0.1:10000, etc.
+        servers = ["mongodb://instrumentald-atlas-test:<PASSWORD>@cluster0-shard-00-00-uvipm.mongodb.net:27017", "mongodb://instrumentald-atlas-test:<PASSWORD>@cluster0-shard-00-01-uvipm.mongodb.net:27017", "mongodb://instrumentald-atlas-test:<PASSWORD>@cluster0-shard-00-02-uvipm.mongodb.net:27017"]
+        tagexclude = ["state", "host"]
 
-          [inputs.mongodb.ssl]
-          enabled = true
+        [inputs.mongodb.ssl]
+        enabled = true
 
 
-      CONF
-    end
+    CONF
   end
 
   # No-scheme, one host
-  %w(
-    test-no-scheme.com
-  ).map do |str|
-    its(:stdout) do
-        should include(<<~CONF)
-        [[inputs.mongodb]]
-        #   ## An array of URI to gather stats about. Specify an ip or hostname
-        #   ## with optional port add password. ie,
-        #   ##   mongodb://user:auth_key@10.10.3.30:27017,
-        #   ##   mongodb://10.10.3.33:18832,
-        #   ##   10.0.0.1:10000, etc.
-          servers = ["#{str}:27017"]
-          tagexclude = ["state", "host"]
+  its(:stdout) do
+      should include(<<~CONF)
+      [[inputs.mongodb]]
+      #   ## An array of URI to gather stats about. Specify an ip or hostname
+      #   ## with optional port add password. ie,
+      #   ##   mongodb://user:auth_key@10.10.3.30:27017,
+      #   ##   mongodb://10.10.3.33:18832,
+      #   ##   10.0.0.1:10000, etc.
+        servers = ["test-no-scheme.com:27017"]
+        tagexclude = ["state", "host"]
 
 
-      CONF
-    end
+    CONF
   end
 
 end

--- a/test/integration/default/serverspec/instrumentald_spec.rb
+++ b/test/integration/default/serverspec/instrumentald_spec.rb
@@ -9,13 +9,20 @@ details = {
   has_pid:          true,
   pid_path:         "/opt/instrumentald/instrumentald.pid",
   owner:            "nobody",
-  service_name:     "instrumentald"
+  service_name:     "instrumentald",
+  log_path:         "/opt/instrumentald/instrumentald.log",
 }
 
 
 describe service(details[:service_name]) do
   it { should be_enabled }
   it { should be_running }
+end
+
+# "should be_running" doesn't seem to work, probably because the init.d script
+# has an exit status of 0 when it is NOT running.
+describe command('sudo /etc/init.d/instrumentald status') do
+  its(:stdout) { should match /"instrumentald" is running/ }
 end
 
 if details[:has_pid]
@@ -32,4 +39,93 @@ describe file(details[:config]) do
   if details[:check_owner]
     it { should be_owned_by(details[:owner]) }
   end
+end
+
+describe file(details[:log_path]) do
+  it { should be_file }
+  if details[:check_owner]
+    it { should be_owned_by(details[:owner]) }
+  end
+  # it { should contain 'ServerName www.example.jp' }
+  process_start_log_line = 'instrumentald\sversion\s.*\sstarted.*'
+  its(:content) do
+    should match %r{
+      #{process_start_log_line}        # find the last process start
+      (?!#{process_start_log_line})    # (it is because there isn't a start later)
+
+      # Then check the log of just the last run
+      Attempting\sconnection\sto\soutput:\sinstrumental
+    }mx
+  end
+end
+
+wait_for_telegraf_conf = %Q{for i in `seq 1 20`; do ls -tr /tmp/instrumentald_telegraf* 2>&1 && break; echo "waiting"; sleep 1; done}
+cat_telegraf_conf = %Q{cat `(ls -tr /tmp/instrumentald_telegraf* || echo "no_tmp_telegraf_files_found") | tail -n 1` 2>&1}
+describe command("#{wait_for_telegraf_conf}; #{cat_telegraf_conf}") do
+
+  # Plain, one host, mongodb scheme
+  %w(
+    localhost
+  ).map do |str|
+    its(:stdout) do
+        should include(<<~CONF)
+        [[inputs.mongodb]]
+        #   ## An array of URI to gather stats about. Specify an ip or hostname
+        #   ## with optional port add password. ie,
+        #   ##   mongodb://user:auth_key@10.10.3.30:27017,
+        #   ##   mongodb://10.10.3.33:18832,
+        #   ##   10.0.0.1:10000, etc.
+          servers = ["mongodb://#{str}:27017"]
+          tagexclude = ["state", "host"]
+
+
+      CONF
+    end
+  end
+
+  # Multi-host, mongodb scheme
+  [
+    "instrumentald-atlas-test:<PASSWORD>@cluster0-shard-00-00-uvipm.mongodb.net",
+    "instrumentald-atlas-test:<PASSWORD>@cluster0-shard-00-01-uvipm.mongodb.net",
+    "instrumentald-atlas-test:<PASSWORD>@cluster0-shard-00-02-uvipm.mongodb.net",
+  ].map do |str|
+    its(:stdout) do
+        should include(<<~CONF)
+        [[inputs.mongodb]]
+        #   ## An array of URI to gather stats about. Specify an ip or hostname
+        #   ## with optional port add password. ie,
+        #   ##   mongodb://user:auth_key@10.10.3.30:27017,
+        #   ##   mongodb://10.10.3.33:18832,
+        #   ##   10.0.0.1:10000, etc.
+          servers = ["mongodb://#{str}:27017"]
+          tagexclude = ["state", "host"]
+
+          [inputs.mongodb.ssl]
+          enabled = true
+
+
+      CONF
+    end
+  end
+
+  # No-scheme, one host
+  %w(
+    test-no-scheme.com
+  ).map do |str|
+    its(:stdout) do
+        should include(<<~CONF)
+        [[inputs.mongodb]]
+        #   ## An array of URI to gather stats about. Specify an ip or hostname
+        #   ## with optional port add password. ie,
+        #   ##   mongodb://user:auth_key@10.10.3.30:27017,
+        #   ##   mongodb://10.10.3.33:18832,
+        #   ##   10.0.0.1:10000, etc.
+          servers = ["#{str}:27017"]
+          tagexclude = ["state", "host"]
+
+
+      CONF
+    end
+  end
+
 end


### PR DESCRIPTION
Previously Atlas URIs didn't work because telegraf couldn't parse the
ssl options. Here we add parsing that transforms Atlas URIs into
configuration blocks that telegraf understands.

This uses the Mongo ruby driver to parse URIs, but unfortunately
requires some shimming which you'll see in the code change.

This also updates the tests to include MongoDB configuration so we can
verify we process these into the correct telegraf config. In order to
test the telegraf config we had to move away from storing it in a
tempfile. The tempfile was getting deleted when a temporary forked
process exited, which called the tempfile's finalize method.

The general approach here is to break apart a MongoDB URI into its
multiple server components and specify a telegraf config block for
each, along with the appropriate ssl config for each.

This also adds another test to ensure instrumentald is running because
there are cases where `should be_running` passes incorrectly (notably
whenever the instrumentald init.d script is used because it always
exits with a success status, whether or not the process is running).