### PR TITLE
Install systemd script with deb and fix related issues

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,7 @@ SUPPORTED_DISTROS      = {
   ]
 }
 EXTRA_ARGS             = {
-  'deb' => '--deb-init debian/instrumentald --after-install debian/after-install.sh --before-remove debian/before-remove.sh --after-remove debian/after-remove.sh --deb-user nobody --deb-group nogroup',
+  'deb' => '--deb-init debian/instrumentald --deb-systemd systemd/instrumentald.service --after-install debian/after-install.sh --before-remove debian/before-remove.sh --after-remove debian/after-remove.sh --deb-user nobody --deb-group nogroup',
   'rpm' => '--rpm-init rpm/instrumentald --after-install rpm/after-install.sh --before-remove rpm/before-remove.sh --after-remove rpm/after-remove.sh --rpm-user nobody --rpm-group nobody --rpm-os linux --rpm-attr "-,nobody,nobody:/opt/instrumentald/" --directories /opt/instrumentald/',
   "osxpkg" => "--osxpkg-identifier-prefix com.instrumentalapp --name instrumentald --after-install osx/after-install.sh --osxpkg-dont-obsolete /etc/instrumentald.toml", # remove doesn't exist on osx
 }

--- a/puppet/.kitchen.yml
+++ b/puppet/.kitchen.yml
@@ -23,6 +23,11 @@ platforms:
     driver_config:
       box: nocm_ubuntu-12.04
       box_url: https://atlas.hashicorp.com/puppetlabs/boxes/ubuntu-12.04-64-nocm/versions/1.0.1/providers/virtualbox.box
+  - name: nocm_ubuntu-16.04
+    driver_plugin: vagrant
+    driver_config:
+      box: nocm_ubuntu-16.04
+      box_url: https://atlas.hashicorp.com/puppetlabs/boxes/ubuntu-16.04-64-nocm/versions/1.0.0/providers/virtualbox.box
   - name: nocm_centos-6.6
     driver_plugin: vagrant
     driver_config:

--- a/puppet/instrumentald/manifests/init.pp
+++ b/puppet/instrumentald/manifests/init.pp
@@ -38,7 +38,7 @@ class instrumentald(
     owner   => "nobody",
     mode    => "0700",
     before => Package["instrumentald"],
-    notify  => Exec["instrumentald-restart"]
+    notify  => Service['instrumentald']
   }
 
   file { "/tmp/instrumentald_scripts/test_script.bash":
@@ -46,7 +46,7 @@ class instrumentald(
     mode    => "0700",
     before => Package["instrumentald"],
     content => template("instrumentald/test_script.bash.erb"),
-    notify  => Exec["instrumentald-restart"]
+    notify  => Service['instrumentald']
   }
 
   file { "instrumental-config":
@@ -55,12 +55,12 @@ class instrumentald(
     mode    => "0440",
     require => Package["instrumentald"],
     content => template("instrumentald/instrumentald.toml.erb"),
-    notify  => Exec["instrumentald-restart"]
+    notify  => Service['instrumentald']
   }
 
-  exec { "instrumentald-restart" :
-    refreshonly => true,
-    command     => "/etc/init.d/instrumentald restart",
-    user        => "root"
+  service { 'instrumentald':
+    ensure  => 'running',
+    enable  => true,
+    require => File['instrumental-config'],
   }
 }

--- a/systemd/instrumentald.service
+++ b/systemd/instrumentald.service
@@ -4,9 +4,11 @@ After=syslog.target
 After=network.target
 
 [Service]
-Type=simple
-ExecStart=/opt/instrumentald/instrumentald -c /etc/instrumentald.toml -p /opt/instrumentald/instrumentald.pid -l /opt/instrumentald/instrumentald.log -s /opt/instrumentald/.instrumental_scripts -t /opt/instrumentald/ foreground
-
+Type=forking
+PIDFile=/opt/instrumentald/instrumentald.pid
+ExecStart=/opt/instrumentald/instrumentald -c /etc/instrumentald.toml -p /opt/instrumentald/instrumentald.pid -l /opt/instrumentald/instrumentald.log -s /opt/instrumentald/.instrumental_scripts -t /opt/instrumentald/ start
+User=nobody
+Group=nogroup
 TimeoutSec=60
 
 [Install]

--- a/test/integration/default/serverspec/instrumentald_spec.rb
+++ b/test/integration/default/serverspec/instrumentald_spec.rb
@@ -21,8 +21,8 @@ end
 
 # "should be_running" doesn't seem to work, probably because the init.d script
 # has an exit status of 0 when it is NOT running.
-describe command('sudo /etc/init.d/instrumentald status') do
-  its(:stdout) { should match /"instrumentald" is running/ }
+describe command('sudo /etc/init.d/instrumentald status; sudo systemctl status instrumentald') do
+  its(:stdout) { should match /("instrumentald" is running|Active: active \(running\))/ }
 end
 
 if details[:has_pid]


### PR DESCRIPTION
Previously in the deb the init.d script was included, but not the
systemd script. FPM has an option for it, so this PR adds that option.
This results in the systemd script being installed when you install the
deb. That makes interfacing through puppet easier using Service.

This uncovered an issue with the previous systemd script where the log
file option wasn't taking effect because the "foreground" command
logged to stdout.

This PR also updates the systemd script to work around that issue.