### PR TITLE
Update telegraf.conf.erb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.1.0 [August 30 1, 2018]
+ * Correct version config in the postgresql_extensible section to improve postgresql 10 compatibility
+
 ### 1.1.0 [August 1, 2017]
  * Upgrade Telegraf to 1.2.1 to prevent MacOS crash bug
  * Fix systemd script when installing from debs, and other systemd fixes

--- a/chef/instrumentald/attributes/default.rb
+++ b/chef/instrumentald/attributes/default.rb
@@ -1,7 +1,7 @@
 default[:instrumental]                   = {}
 default[:instrumental][:project_token]   = "YOUR_PROJECT_TOKEN"
 
-default[:instrumental][:version]         = "1.1.0"
+default[:instrumental][:version]         = "1.1.1"
 default[:instrumental][:repo]            = "https://s3.amazonaws.com/instrumentald"
 
 default[:instrumental][:curl_path]       = "/usr/bin/curl"

--- a/lib/instrumentald/version.rb
+++ b/lib/instrumentald/version.rb
@@ -1,3 +1,3 @@
 module Instrumentald
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/lib/telegraf/telegraf.conf.erb
+++ b/lib/telegraf/telegraf.conf.erb
@@ -1006,13 +1006,11 @@
   ]
   [[inputs.postgresql_extensible.query]]
     sqlquery="SELECT * FROM pg_stat_database WHERE datname"
-    version=901
     withdbname=true
     tagvalue=""
     measurement=""
   [[inputs.postgresql_extensible.query]]
     sqlquery="SELECT * FROM pg_stat_bgwriter"
-    version=901
     withdbname=false
     tagvalue=""
     measurement=""

--- a/puppet/instrumentald/metadata.json
+++ b/puppet/instrumentald/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "instrumental-instrumentald",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Expected Behavior",
   "license": "MIT",
   "source": "https://github.com/instrumental/instrumentald",


### PR DESCRIPTION
this version is not necessary for 9+ and screws up compatibility with pg 10. pg 8 was EOL'ed in 2014.