### PR TITLE
Ubuntu 18 debian 9

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,8 +31,10 @@ SUPPORTED_DISTROS      = {
     'ubuntu/precise', # 12.04
     'ubuntu/trusty',  # 14.04
     'ubuntu/xenial',  # 16.04
+    'ubuntu/bionic',  # 18.04
     'debian/wheezy',  # 7.0
-    'debian/jessie'   # 8.0
+    'debian/jessie',  # 8.0
+    'debian/stretch', # 9.0
   ],
   'rpm' => [
     'el/5',

--- a/chef/.kitchen.yml
+++ b/chef/.kitchen.yml
@@ -13,9 +13,11 @@ provisioner:
 platforms:
   - name: debian-7.11
   - name: debian-8.7
+  - name: debian-9.4
   - name: ubuntu-12.04
   - name: ubuntu-14.04
   - name: ubuntu-16.04
+  - name: ubuntu-18.04
   - name: centos-6.7
 
 suites:


### PR DESCRIPTION
Release packages for Ubuntu 18 and Debian 9, with no other changes.  Not a new release.